### PR TITLE
ascii doc update and image reference fixes

### DIFF
--- a/opennms-pris-docs/pom.xml
+++ b/opennms-pris-docs/pom.xml
@@ -71,7 +71,7 @@
           <headerFooter>true</headerFooter>
           <sourceDirectory>${asciidoc.source.directory}</sourceDirectory>
           <outputDirectory>${asciidoc.output.directory}</outputDirectory>
-          <imagesDir>./</imagesDir>
+          <imagesDir>images</imagesDir>
           <attributes>
             <docVersion>${project.version}</docVersion>
           </attributes>

--- a/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
+++ b/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
@@ -1,3 +1,5 @@
+// Allow GitHub image rendering
+:imagesdir: images
 
 [[doc-guidelines]]
 == Documentation guidelines

--- a/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
+++ b/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
@@ -213,23 +213,23 @@ To include an image file, make sure it resides in the 'images/' directory relati
 
 [source]
 ----
-image::../images/opennms-logo.png[]
+image::opennms-logo.png[]
 ----
 
 Which is rendered as:
 
-image::../images/opennms-logo.png[]
+image::opennms-logo.png[]
 
 [source]
 ----
 .example.odp
-image::../images/example.png[example.odp]
+image::example.png[example.odp]
 ----
 
 Which is rendered as:
 
 .example.odp
-image::../images/example.png[example.odp]
+image::example.png[example.odp]
 
 === Attributes
 

--- a/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
+++ b/opennms-pris-docs/src/asciidoc/doc-guidelines.adoc
@@ -213,23 +213,23 @@ To include an image file, make sure it resides in the 'images/' directory relati
 
 [source]
 ----
-image::images/opennms-logo.png[]
+image::../images/opennms-logo.png[]
 ----
 
 Which is rendered as:
 
-image::images/opennms-logo.png[]
+image::../images/opennms-logo.png[]
 
 [source]
 ----
 .example.odp
-image::images/example.png[example.odp]
+image::../images/example.png[example.odp]
 ----
 
 Which is rendered as:
 
 .example.odp
-image::images/example.png[example.odp]
+image::../images/example.png[example.odp]
 
 === Attributes
 

--- a/opennms-pris-docs/src/asciidoc/introduction.adoc
+++ b/opennms-pris-docs/src/asciidoc/introduction.adoc
@@ -21,7 +21,7 @@ The _PRIS_ components are shown in <<pris_overview>>.
 === Overview
 
 .OpenNMS PRIS overview
-image::../images/pris-overview.png[OpenNMS PRIS overview]
+image::pris-overview.png[OpenNMS PRIS overview]
 
 The components from left to right are described as followed:
 

--- a/opennms-pris-docs/src/asciidoc/introduction.adoc
+++ b/opennms-pris-docs/src/asciidoc/introduction.adoc
@@ -1,3 +1,6 @@
+// Allow GitHub image rendering
+:imagesdir: images
+
 [[introduction]]
 == Introduction
 If you have a large network and discovery doesn't help, it helps to find a source of truth for starting to fill your management system.

--- a/opennms-pris-docs/src/asciidoc/introduction.adoc
+++ b/opennms-pris-docs/src/asciidoc/introduction.adoc
@@ -21,7 +21,7 @@ The _PRIS_ components are shown in <<pris_overview>>.
 === Overview
 
 .OpenNMS PRIS overview
-image::images/pris-overview.png[OpenNMS PRIS overview]
+image::../images/pris-overview.png[OpenNMS PRIS overview]
 
 The components from left to right are described as followed:
 

--- a/opennms-pris-docs/src/asciidoc/quickstart.adoc
+++ b/opennms-pris-docs/src/asciidoc/quickstart.adoc
@@ -6,7 +6,7 @@ The first requisition has a worksheet containing all routers and the second work
 This example can be found in `examples/source/xlsExample`.
 
 .Worksheet with Router
-image::images/myRouter.png[myRouter.png]
+image::../images/myRouter.png[myRouter.png]
 
 In line 5, 6 and 7 there is a router defined with more than one IP interface.
 All three interfaces will be manually provisioned.
@@ -16,7 +16,7 @@ For all other IP interfaces you can use the OpenNMS Provisiond mechanism scannin
 The server will also be categorized in _Backbone_ and _Office_.
 
 .Worksheet with Server
-image::images/myServer.png[myServer.png]
+image::../images/myServer.png[myServer.png]
 
 The _OpenNMS_ requisition should be provided via _HTTP_ and we use _OpenNMS Provisiond_ to synchronize it on a regular basis.
 We build the following file structure:
@@ -76,7 +76,7 @@ All changes will be applied from the next request against the server.
 With the given configuration you see the result of the OpenNMS requisitions with the URL http://localhost:8000/requisitions/myRouter and http://localhost:8000/requisitions/myServer which can be used in _OpenNMS Provisiond_.
 
 .Output of _PRIS_ server for both configured requisitions
-image::images/requisitions-http.png[requisitions-http.png]
+image::../images/requisitions-http.png[requisitions-http.png]
 
 To get the requisition provided from _PRIS_ automatically into OpenNMS you can configure Provisiond with a schedule.
 Create following to entries in `provisiond-configuration.xml` and they will automatically be synchronized every night at 0h:0m:0s and 1h:0m:0s.

--- a/opennms-pris-docs/src/asciidoc/quickstart.adoc
+++ b/opennms-pris-docs/src/asciidoc/quickstart.adoc
@@ -6,7 +6,7 @@ The first requisition has a worksheet containing all routers and the second work
 This example can be found in `examples/source/xlsExample`.
 
 .Worksheet with Router
-image::../images/myRouter.png[myRouter.png]
+image::myRouter.png[myRouter.png]
 
 In line 5, 6 and 7 there is a router defined with more than one IP interface.
 All three interfaces will be manually provisioned.
@@ -16,7 +16,7 @@ For all other IP interfaces you can use the OpenNMS Provisiond mechanism scannin
 The server will also be categorized in _Backbone_ and _Office_.
 
 .Worksheet with Server
-image::../images/myServer.png[myServer.png]
+image::myServer.png[myServer.png]
 
 The _OpenNMS_ requisition should be provided via _HTTP_ and we use _OpenNMS Provisiond_ to synchronize it on a regular basis.
 We build the following file structure:
@@ -76,7 +76,7 @@ All changes will be applied from the next request against the server.
 With the given configuration you see the result of the OpenNMS requisitions with the URL http://localhost:8000/requisitions/myRouter and http://localhost:8000/requisitions/myServer which can be used in _OpenNMS Provisiond_.
 
 .Output of _PRIS_ server for both configured requisitions
-image::../images/requisitions-http.png[requisitions-http.png]
+image::requisitions-http.png[requisitions-http.png]
 
 To get the requisition provided from _PRIS_ automatically into OpenNMS you can configure Provisiond with a schedule.
 Create following to entries in `provisiond-configuration.xml` and they will automatically be synchronized every night at 0h:0m:0s and 1h:0m:0s.

--- a/opennms-pris-docs/src/asciidoc/quickstart.adoc
+++ b/opennms-pris-docs/src/asciidoc/quickstart.adoc
@@ -1,3 +1,5 @@
+// Allow GitHub image rendering
+:imagesdir: images
 
 [[quickstart-example]]
 == Quickstart example

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <!-- Version settings -->
     <apacheDerbyVersion>10.10.2.0</apacheDerbyVersion>
-    <asciidoctorVersion>1.5.0</asciidoctorVersion>
+    <asciidoctorVersion>1.5.2</asciidoctorVersion>
     <beanshellVersion>2.0b5</beanshellVersion>
     <chQosLogbackVersion>1.1.2</chQosLogbackVersion>
     <commonsConfigurationVersion>1.10</commonsConfigurationVersion>


### PR DESCRIPTION
- ascii doc 1.5.2
- docu references images more direct
- added ":imagesdir: images" entries on docu files to make images work in github editor