### PR TITLE
Fix typo in heading for strict ip-filter WhiteAndBlackOnly

### DIFF
--- a/opennms-pris-docs/src/asciidoc/mapper/mapper.ocs.adoc
+++ b/opennms-pris-docs/src/asciidoc/mapper/mapper.ocs.adoc
@@ -85,7 +85,7 @@ If it is blacklisted, no interface is added to the node. (+selectManagementNetwo
 The IP address of an +snmpDevice+ is elected as management interface as long as it is not blacklisted.
 If it is blacklisted, no interface is added to the node. (+selectIpAddress+)
 
-===== Strict ip-filter "WhiteAndBackOnly"
+===== Strict ip-filter "WhiteAndBlackOnly"
 This filter implements a strict black- and whitelist approach.
 Computers and +snmpDevices+ are handled independently.
 


### PR DESCRIPTION
The typo is in the heading, I think it means WhiteAndBlackOnly instead of WhiteAndBackOnly.