### PR TITLE
PRIS-138: Fix opennms-pris.bat classpath call

### DIFF
--- a/opennms-pris-dist/src/main/resources/opennms-pris.bat
+++ b/opennms-pris-dist/src/main/resources/opennms-pris.bat
@@ -1,4 +1,3 @@
 @echo off
 cd "%~dp0"
-java %* -cp "%~dp0lib*";"%~dp0opennms-pris.jar" org.opennms.pris.Starter
-
+java %* -cp "%~dp0lib\*";"%~dp0opennms-pris.jar" org.opennms.pris.Starter


### PR DESCRIPTION
Fix classpath call in opennms-pris.bat.

* JIRA: https://issues.opennms.org/browse/PRIS-138