### PR TITLE
Continuous release and integration with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,220 @@
+version: 2.0
+
+defaults: &defaults
+
+  working_directory: /home/circleci/pris
+
+  workspace_root: &workspace_root
+    /tmp/workspace
+
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: *workspace_root
+
+jobs:
+  compile_n_junit:
+    <<: *defaults
+    docker:
+      - image: circleci/openjdk:8-jdk
+
+    steps:
+      - *attach_workspace
+      - checkout
+      - restore_cache:
+          key: pris-repository-{{ checksum "pom.xml" }}
+      - run:
+          name: Generate version number for this release
+          command: |
+            echo "export VERSION=$(git describe)-b${CIRCLE_BUILD_NUM}" >> ${BASH_ENV}
+      - run:
+          name: Set version number
+          command: |
+            echo "Set version number for build to: ${VERSION}"
+            bin/changeversion.sh -o NEXT-MAJOR -n ${VERSION}
+      - run:
+          name: Validate Maven project
+          command: |
+            mvn validate
+      - run:
+          name: Compile application
+          command: |
+            mvn compile
+      - run:
+          name: Run Unit tests
+          command: |
+            mvn test
+      - run:
+          name: Package into distributable format
+          command: |
+            mvn package -DskipTests
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: pris-repository-{{ checksum "pom.xml" }}
+      - store_artifacts:
+          path: opennms-pris-dist/target/pris-release-archive.tar.gz
+      - store_artifacts:
+          path: opennms-pris-dist/target/pris-release-archive.zip
+      - run:
+          name: Persist PRIS release archive in workspace
+          command: |
+            cp opennms-pris-dist/target/pris-release-archive.tar.gz /tmp/workspace
+            cp opennms-pris-dist/target/pris-release-archive.zip /tmp/workspace
+      - run:
+          name: Persist version number
+          command: |
+            echo ${VERSION} > /tmp/workspace/version.txt
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - pris-release-archive.tar.gz
+            - opennms-pris-dist/target/pris-release-archive.zip
+            - version.txt
+
+  build_docker_image:
+    <<: *defaults
+    docker:
+      - image: docker:17.11.0-ce-git
+
+    steps:
+      - setup_remote_docker
+      - *attach_workspace
+      - checkout
+      - run:
+          name: Build Docker Container Image
+          command: |
+            cd Docker
+            cp /tmp/workspace/pris-release-archive.tar.gz deploy/pris-release-archive.tar.gz
+            docker build --build-arg OPENNMS_PRIS_VERSION=$(cat /tmp/workspace/version.txt) -t opennms/pris:$(cat /tmp/workspace/version.txt) .
+      - run:
+          name: Persist Docker Container Image
+          command: |
+            docker image save opennms/pris:$(cat /tmp/workspace/version.txt) -o /tmp/workspace/pris-docker-image
+      - store_artifacts:
+          path: /tmp/workspace/pris-docker-image
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - pris-docker-image
+
+  smoke_test:
+    <<: *defaults
+    docker:
+      - image: docker:17.11.0-ce
+
+    steps:
+      - setup_remote_docker
+      - *attach_workspace
+      - run:
+          name: Load PRIS Docker Container Image
+          command: |
+            docker image load -i /tmp/workspace/pris-docker-image
+      - run:
+          name: Run PRIS Docker Container Image and keep Container ID
+          command: |
+            echo "export PRIS_CONTAINER_ID=$(docker run --rm --detach --name pris_$(cat /tmp/workspace/version.txt) opennms/pris:$(cat /tmp/workspace/version.txt))" >> ${BASH_ENV}
+            sleep 3
+      - run:
+          name: Smoke test against application landing page with redirect to documentation
+          command: |
+            source ${BASH_ENV}
+            docker exec ${PRIS_CONTAINER_ID} curl -L -f -I http://localhost:8000
+      - run:
+          name: Smoke test against example requisition named MyRouter
+          command: |
+            source ${BASH_ENV}
+            docker exec ${PRIS_CONTAINER_ID} curl -f http://localhost:8000/requisitions/myRouter > myRouter.xml
+      - run:
+          name: Smoke test against example requisition named MyServer
+          command: |
+            source ${BASH_ENV}
+            docker exec ${PRIS_CONTAINER_ID} curl -f http://localhost:8000/requisitions/myServer > myServer.xml
+      - store_artifacts:
+          path: myRouter.xml
+      - store_artifacts:
+          path: myServer.xml
+      - run:
+          name: Tear down smoke test environment
+          command: |
+            source ${BASH_ENV}
+            docker stop ${PRIS_CONTAINER_ID}
+            docker rmi opennms/pris:$(cat /tmp/workspace/version.txt)
+
+  publish_latest_2_DockerHub:
+      <<: *defaults
+      docker:
+        - image: docker:17.11.0-ce
+
+      steps:
+        - setup_remote_docker
+        - *attach_workspace
+        - run:
+            name: DockerHub Login
+            command: |
+              docker login -u ${dockerhub_login} -p ${dockerhub_pass}
+        - run:
+            name: Load Docker Container Image file
+            command: |
+              docker image load -i /tmp/workspace/pris-docker-image
+        - run:
+            name: Tag Docker Container Images as latest release
+            command: |
+              docker tag opennms/pris:$(cat /tmp/workspace/version.txt) opennms/pris:latest
+        - run:
+            name: Publish latest release Docker Container Image to DockerHub
+            command: |
+              docker push opennms/pris:latest
+              docker push opennms/pris:$(cat /tmp/workspace/version.txt)
+
+  publish_bleeding_2_DockerHub:
+      <<: *defaults
+      docker:
+        - image: docker:17.11.0-ce
+
+      steps:
+        - setup_remote_docker
+        - *attach_workspace
+        - run:
+            name: DockerHub Login
+            command: |
+              docker login -u ${dockerhub_login} -p ${dockerhub_pass}
+        - run:
+            name: Load Docker Container Image file
+            command: |
+              docker image load -i /tmp/workspace/pris-docker-image
+        - run:
+            name: Tag Docker Container Images as bleeding edge
+            command: |
+              docker tag opennms/pris:$(cat /tmp/workspace/version.txt) opennms/pris:bleeding
+        - run:
+            name: Publish bleeding edge Docker Container Image to DockerHub
+            command: |
+              docker push opennms/pris:bleeding
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - compile_n_junit
+      - build_docker_image:
+          requires:
+            - compile_n_junit
+      - smoke_test:
+          requires:
+            - build_docker_image
+      - publish_latest_2_DockerHub:
+          filters:
+            branches:
+              only:
+                - /release-.*/
+          requires:
+            - smoke_test
+            - build_docker_image
+      - publish_bleeding_2_DockerHub:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - smoke_test
+            - build_docker_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,8 @@ jobs:
             name: Collect artifacts to publish latest release on GitHub
             command: |
               mkdir github-latest
-              cp /tmp/workspace/pris-release-archive.tar.gz github-latest/pris-$(cat /tmp/workspace/version.txt)-archive.tar.gz
-              cp /tmp/workspace/pris-release-archive.zip github-latest/pris-$(cat /tmp/workspace/version.txt)-archive.zip
+              cp /tmp/workspace/pris-release-archive.tar.gz github-latest/pris-release-$(cat /tmp/workspace/version.txt).tar.gz
+              cp /tmp/workspace/pris-release-archive.zip github-latest/pris-release-$(cat /tmp/workspace/version.txt).zip
         - run:
             name: Publish latest archives to GitHub
             command: |
@@ -228,8 +228,8 @@ jobs:
             name: Collect artifacts to publish bleeding release on GitHub
             command: |
               mkdir github-bleeding
-              cp /tmp/workspace/pris-release-archive.tar.gz github-bleeding/pris-bleeding-archive.tar.gz
-              cp /tmp/workspace/pris-release-archive.zip github-bleeding/pris-bleeding-archive.zip
+              cp /tmp/workspace/pris-release-archive.tar.gz github-bleeding/pris-bleeding-$(cat /tmp/workspace/version.txt)-.tar.gz
+              cp /tmp/workspace/pris-release-archive.zip github-bleeding/pris-bleeding-$(cat /tmp/workspace/version.txt).zip
         - run:
             name: Publish bleeding archives to GitHub
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           root: *workspace_root
           paths:
             - pris-release-archive.tar.gz
-            - opennms-pris-dist/target/pris-release-archive.zip
+            - pris-release-archive.zip
             - version.txt
 
   build_docker_image:
@@ -191,6 +191,61 @@ jobs:
             command: |
               docker push opennms/pris:bleeding
 
+  publish_latest_2_GitHub:
+      <<: *defaults
+      docker:
+        - image: circleci/golang
+
+      steps:
+        - *attach_workspace
+        - run:
+            name: Install ghr tool to create GitHub releases and upload artifacts
+            command: |
+              go get -u github.com/tcnksm/ghr
+        - run:
+            name: Collect artifacts to publish latest release on GitHub
+            command: |
+              mkdir github-latest
+              cp /tmp/workspace/pris-release-archive.tar.gz github-latest/pris-$(cat /tmp/workspace/version.txt)-archive.tar.gz
+              cp /tmp/workspace/pris-release-archive.zip github-latest/pris-$(cat /tmp/workspace/version.txt)-archive.zip
+        - run:
+            name: Publish latest archives to GitHub
+            command: |
+              ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} $(cat /tmp/workspace/version.txt) github-latest
+
+  publish_bleeding_2_GitHub:
+      <<: *defaults
+      docker:
+        - image: circleci/golang
+
+      steps:
+        - *attach_workspace
+        - run:
+            name: Install ghr tool to create GitHub releases and upload artifacts
+            command: |
+              go get -u github.com/tcnksm/ghr
+        - run:
+            name: Collect artifacts to publish bleeding release on GitHub
+            command: |
+              mkdir github-bleeding
+              cp /tmp/workspace/pris-release-archive.tar.gz github-bleeding/pris-bleeding-archive.tar.gz
+              cp /tmp/workspace/pris-release-archive.zip github-bleeding/pris-bleeding-archive.zip
+        - run:
+            name: Publish bleeding archives to GitHub
+            command: |
+              ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} bleeding-$(cat /tmp/workspace/version.txt) github-bleeding
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - compile_n_junit
+      - publish_latest_2_GitHub:
+          requires:
+            - compile_n_junit
+      - publish_bleeding_2_GitHub:
+          requires:
+            - compile_n_junit
+
 workflows:
   version: 2
   build_and_deploy:
@@ -202,6 +257,20 @@ workflows:
       - smoke_test:
           requires:
             - build_docker_image
+      - publish_latest_2_GitHub:
+          filters:
+            branches:
+              only:
+                - /release-.*/
+          requires:
+            - smoke_test
+      - publish_bleeding_2_GitHub:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - smoke_test
       - publish_latest_2_DockerHub:
           filters:
             branches:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.class
 target/
 # Package Files #
+Docker/deploy/*
 *.jar
 *.war
 *.ear

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM opennms/openjdk:8u151-jdk
+
+LABEL maintainer "Ronny Trommer <ronny@opennms.org>"
+
+ARG OPENNMS_PRIS_VERSION=SNAPSHOT
+ARG OPENNMS_PRIS_HOME=/opt/opennms-pris
+ENV JAVA_OPTS ""
+
+COPY ./deploy/pris-release-archive.tar.gz /tmp
+
+RUN yum -y --setopt=tsflags=nodocs update && \
+    mkdir -p ${OPENNMS_PRIS_HOME} && \
+    tar xzf /tmp/pris-release-archive.tar.gz -C ${OPENNMS_PRIS_HOME} --strip-components=1 && \
+    yum clean all && \
+    rm -rf /tmp/*.tar.gz && \
+    rm -rf /var/cache/yum
+
+## Volumes for storing data outside of the container
+VOLUME [ "${OPENNMS_PRIS_HOME}/requisitions", "${OPENNMS_PRIS_HOME}/scriptsteps" ]
+
+WORKDIR ${OPENNMS_PRIS_HOME}
+
+LABEL license="AGPLv3" \
+      org.opennms.horizon.version="${OPENNMS_PRIS_VERSION}" \
+      vendor="OpenNMS Community" \
+      name="PRIS"
+
+ENTRYPOINT ./opennms-pris.sh
+
+EXPOSE 8000

--- a/Docker/deploy/.gitkeep
+++ b/Docker/deploy/.gitkeep
@@ -1,0 +1,1 @@
+# This directory is by default empty and is a target for deployable OpenNMS PRIS distribution as tar.gz file.

--- a/bin/changeversion.sh
+++ b/bin/changeversion.sh
@@ -4,13 +4,11 @@
 #
 # Usage example:
 #   changeversion.sh -o 1.0.4-SNAPSHOT -n 1.0.5-SNAPSHOT
-# 
+#
 # Created:
 #   ronny@opennms.org
 #
 
-# Change to project root and save current work directory
-cd ..
 CWD=$(pwd)
 
 # Turn on debug mode
@@ -18,7 +16,7 @@ CWD=$(pwd)
 
 #
 # Function print usage help text
-# 
+#
 printUsage() {
   echo ""
   echo "Script to change the version number in pom.xml files"
@@ -53,8 +51,7 @@ while [ $# -gt 0 ] ; do
 done
 
 # Go through all pom.xml files and replace the given version number
-for i in $(find ${CWD} -name "pom.xml"); do 
+for i in $(find ${CWD} -name "pom.xml"); do
   cat ${i} | sed -e "s/${OLD_VERSION}/${NEW_VERSION}/g" > ${i}.new;
   mv ${i}.new ${i};
 done
-

--- a/opennms-pris-api/pom.xml
+++ b/opennms-pris-api/pom.xml
@@ -2,33 +2,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-  
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-parent</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-  
+
     <artifactId>opennms-pris-api</artifactId>
-  
+
     <packaging>jar</packaging>
-  
+
     <name>OpenNMS :: Provisioning Integration Server :: API</name>
-  
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opennms-pris-model</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-util</artifactId>
         </dependency>
     </dependencies>
-    
-    
+
+
     <build>
         <plugins>
             <!-- Package test classes in JAR -->

--- a/opennms-pris-dist/pom.xml
+++ b/opennms-pris-dist/pom.xml
@@ -3,17 +3,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-parent</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-dist</artifactId>
-    
+
     <packaging>pom</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Distribution</name>
 
     <dependencies>
@@ -23,13 +23,13 @@
             <version>${project.version}</version>
             <type>pom</type>
         </dependency>
-    
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opennms-pris-main</artifactId>
             <version>${project.version}</version>
         </dependency>
-    
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opennms-pris-plugins-defaults</artifactId>
@@ -64,6 +64,7 @@
 
     <build>
         <!-- Build fat JAR -->
+        <finalName>pris</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -92,13 +93,13 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <!-- Build release archives -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
-                
+
                 <executions>
                     <execution>
                         <id>make-assembly</id>
@@ -108,7 +109,7 @@
                         </goals>
                     </execution>
                 </executions>
-                
+
                 <configuration>
                     <descriptors>
                         <descriptor>src/assembly/assembly.xml</descriptor>

--- a/opennms-pris-dist/src/main/resources/opennms-pris.service
+++ b/opennms-pris-dist/src/main/resources/opennms-pris.service
@@ -4,7 +4,7 @@ Description=OpenNMS Provisioning Integration Server
 [Service]
 Type=Simple
 WorkingDirectory=/opt/opennms-pris/
-ExecStart=/usr/bin/java -cp ./lib/*:./opennms-pris.jar org.opennms.pris.Starter
+ExecStart=/usr/bin/java ${JAVA_OPTS} -cp ./lib/*:./opennms-pris.jar org.opennms.pris.Starter
 ExecStop=/bin/kill -TERM $MAINPID
 User=root
 

--- a/opennms-pris-dist/src/main/resources/opennms-pris.sh
+++ b/opennms-pris-dist/src/main/resources/opennms-pris.sh
@@ -10,4 +10,4 @@ PROG="opennms-pris.jar"
 PROG_DIR=`dirname $0`
 PROG_MAIN="org.opennms.pris.Starter"
 
-${JAVA_BIN} -cp ${PROG_DIR}/lib/*:${PROG_DIR}/${PROG} ${PROG_MAIN}
+${JAVA_BIN} ${JAVA_OPTS} -cp ${PROG_DIR}/lib/*:${PROG_DIR}/${PROG} ${PROG_MAIN}

--- a/opennms-pris-docs/pom.xml
+++ b/opennms-pris-docs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-pris-parent</artifactId>
-    <version>1.1.6</version>
+    <version>NEXT-MAJOR</version>
   </parent>
 
   <artifactId>opennms-pris-docs</artifactId>

--- a/opennms-pris-main/pom.xml
+++ b/opennms-pris-main/pom.xml
@@ -2,51 +2,51 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-  
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-parent</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-  
+
     <artifactId>opennms-pris-main</artifactId>
-  
+
     <packaging>jar</packaging>
-  
+
     <name>OpenNMS :: Provisioning Integration Server :: Main</name>
-  
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opennms-pris-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <!-- Logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
-        
+
         <!-- Web-Server -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-rewrite</artifactId>
         </dependency>
-        
-        
+
+
         <!-- Configuration -->
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
         </dependency>
     </dependencies>
-  
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-model/pom.xml
+++ b/opennms-pris-model/pom.xml
@@ -2,19 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-  
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-parent</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-  
+
     <artifactId>opennms-pris-model</artifactId>
-  
+
     <packaging>jar</packaging>
-  
+
     <name>OpenNMS :: Provisioning Integration Server :: Model</name>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
@@ -22,7 +22,7 @@
             <version>0.6.5.1</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Copy the XSDs to the project -->
@@ -50,7 +50,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <!-- Compile XSDs into classes -->
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
@@ -70,16 +70,16 @@
                     <verbose>true</verbose>
                     <debug>true</debug>
                     -->
-                    
+
                     <!-- Configure generated code -->
                     <enableIntrospection>true</enableIntrospection>
 
                     <!-- Specify XSDs -->
                     <schemaDirectory>${basedir}/target/xsds</schemaDirectory>
-                    
+
                     <!-- Specify bindings -->
                     <bindingDirectory>${basedir}/src/main/xjb</bindingDirectory>
-                    
+
                     <args>
                         <arg>-XtoString</arg>
                         <arg>-Xequals</arg>
@@ -87,7 +87,7 @@
                         <arg>-Xfluent-api</arg>
                         <arg>-Xvalue-constructor</arg>
                     </args>
-                    
+
                     <plugins>
                         <dependency>
                             <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/opennms-pris-plugins/opennms-pris-plugins-defaults/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-defaults/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-plugins</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins-defaults</artifactId>
     <packaging>jar</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: Defaults</name>
-        
+
     <dependencies>
         <!-- HTTP Client -->
         <dependency>
@@ -23,7 +23,7 @@
             <version>${httpComponentsVersion}</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-plugins/opennms-pris-plugins-jdbc/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-jdbc/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-plugins</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins-jdbc</artifactId>
     <packaging>jar</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: JDBC</name>
-    
+
     <dependencies>
         <!-- Database Drivers -->
         <dependency>
@@ -27,7 +27,7 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysqlConnectorVersion}</version>
         </dependency>
-        
+
         <!-- Tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -40,9 +40,9 @@
             <version>${apacheDerbyVersion}</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
@@ -3,22 +3,22 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-plugins</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins-ocs</artifactId>
     <packaging>jar</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: OCS</name>
-    
+
     <properties>
         <ocsInventoryClientVersion>1.0.1</ocsInventoryClientVersion>
     </properties>
-    
+
     <dependencies>
         <!-- OCS-Inventory -->
         <dependency>
@@ -26,7 +26,7 @@
             <artifactId>ocs.inventory.client</artifactId>
             <version>${ocsInventoryClientVersion}</version>
         </dependency>
-        
+
         <!-- Tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -34,7 +34,7 @@
             <classifier>tests</classifier>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-plugins</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins-script</artifactId>
     <packaging>jar</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: Script</name>
-        
+
     <dependencies>
         <!-- Languages -->
         <dependency>
@@ -26,7 +26,7 @@
             <artifactId>groovy-all</artifactId>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
@@ -3,22 +3,22 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-plugins</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins-xls</artifactId>
     <packaging>jar</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: XLS</name>
-    
+
     <properties>
         <jexcelApiVersion>2.6.12</jexcelApiVersion>
     </properties>
-    
+
     <dependencies>
         <!-- XLS -->
         <dependency>
@@ -26,7 +26,7 @@
             <artifactId>jxl</artifactId>
             <version>${jexcelApiVersion}</version>
         </dependency>
-        
+
         <!-- Tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -34,7 +34,7 @@
             <classifier>tests</classifier>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <!-- Build fat JAR -->

--- a/opennms-pris-plugins/pom.xml
+++ b/opennms-pris-plugins/pom.xml
@@ -3,16 +3,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-pris-parent</artifactId>
-        <version>1.1.6</version>
+        <version>NEXT-MAJOR</version>
     </parent>
-    
+
     <artifactId>opennms-pris-plugins</artifactId>
     <packaging>pom</packaging>
-    
+
     <name>OpenNMS :: Provisioning Integration Server :: Plugins</name>
 
     <dependencies>
@@ -22,14 +22,14 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-            
+
         <!-- SPI -->
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
         </dependency>
     </dependencies>
-    
+
     <dependencyManagement>
         <dependencies>
             <!-- Tests -->
@@ -50,7 +50,7 @@
         <module>opennms-pris-plugins-script</module>
         <module>opennms-pris-plugins-xls</module>
     </modules>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -59,7 +59,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.3</version>
-                    
+
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -71,9 +71,9 @@
 
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
-                        
+
                         <shadedArtifactAttached>true</shadedArtifactAttached>
-                        
+
                         <transformers>
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                         </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opennms</groupId>
   <artifactId>opennms-pris-parent</artifactId>
-  <version>1.1.6</version>
+  <version>NEXT-MAJOR</version>
 
   <packaging>pom</packaging>
 
@@ -149,13 +149,13 @@
         <artifactId>jetty-server</artifactId>
         <version>${jettyServerVersion}</version>
       </dependency>
-      
+
       <dependency>
          <groupId>org.eclipse.jetty</groupId>
          <artifactId>jetty-rewrite</artifactId>
          <version>${jettyServerVersion}</version>
       </dependency>
-        
+
 
       <!-- SPI -->
       <dependency>
@@ -164,22 +164,22 @@
         <version>${metainfServicesVersion}</version>
         <scope>provided</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
         <version>${groovyVersion}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.beanshell</groupId>
         <artifactId>bsh</artifactId>
         <version>${beanshellVersion}</version>
       </dependency>
-      
+
     </dependencies>
   </dependencyManagement>
-  
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Streamlining the repository to make it possible to continuously release fully automated with CircleCI. Releases are shipped as DockerHub images and runnable archives are pushed to GitHub. Building shipable Docker images are now part of the repository and are used in smoke tests and are deployed as build artifacts. Added smoke test phase where a container is started and smoke tests run against:

* landing page which redirects to the documentation
* myRouter example requisition
* myServer example requisition

The output of the example requisitions is persisted as an artifact of the test phase. Added a publishing workflow for latest, stable and development image to DockerHub based on a branch name filter.
Refactored release versions to following scheme:

* master: is merge target for next release branch, tagged and published as bleeding
* release-*: release branches, tagged and published as specific version number and latest