### PR TITLE
Include more dependencies for groovy to work better

### DIFF
--- a/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
@@ -25,6 +25,10 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-script/pom.xml
@@ -29,6 +29,10 @@
             <groupId>org.apache.ivy</groupId>
             <artifactId>ivy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.gpars</groupId>
+            <artifactId>gpars</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <chQosLogbackVersion>1.2.3</chQosLogbackVersion>
         <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
         <commonsIoVersion>2.6</commonsIoVersion>
+        <gparsVersion>1.2.1</gparsVersion>
         <groovyVersion>2.4.15</groovyVersion>
         <guavaVersion>27.0-jre</guavaVersion>
         <httpComponentsVersion>4.5.6</httpComponentsVersion>
@@ -167,6 +168,11 @@
                 <groupId>org.apache.ivy</groupId>
                 <artifactId>ivy</artifactId>
                 <version>${ivyVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.gpars</groupId>
+                <artifactId>gpars</artifactId>
+                <version>${gparsVersion}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <groovyVersion>2.4.15</groovyVersion>
         <guavaVersion>27.0-jre</guavaVersion>
         <httpComponentsVersion>4.5.6</httpComponentsVersion>
+        <ivyVersion>2.4.0</ivyVersion>
         <jettyServerVersion>9.4.20.v20190813</jettyServerVersion>
         <junitVersion>4.12</junitVersion>
         <mavenResourcesPluginVersion>3.1.0</mavenResourcesPluginVersion>
@@ -161,6 +162,11 @@
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${groovyVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+                <version>${ivyVersion}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Here we add dependencies to all `@Grapes` annotations in groovy scripts.