### PR TITLE
Antora xref validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,12 +91,16 @@ jobs:
       - run:
           name: Install make and bash
           command: |
-            apk add --no-cache make bash
+            apk add --no-cache make bash git openssh-client
+            npm i -g gitlab:antora/xref-validator
+      - run:
+          name: Validate Xrefs in docs
+          command: |
+            NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator antora-playbook-local.yml
       - run:
           name: Generate documentation
           command: |
             make docs
-
       - persist_to_workspace:
           root: ~/
           paths:

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -10,7 +10,7 @@ content:
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.2.0/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.3.1/ui-bundle.zip
 asciidoc:
   attributes:
     stem: latexmath


### PR DESCRIPTION
Added a local Antora build run that produces a static HTML site.zip as an artifact just with the content from the
specific branch. It should give a developer and reviewer quicker feedback for validation. Added also an Xref validation
step which blames when cross-references can't be resolved correctly.