### PR TITLE
Maintenance: Dependency updates with Dependabot

### DIFF
--- a/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
@@ -16,7 +16,7 @@
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: XLS</name>
 
     <properties>
-        <apachePoiVersion>3.17</apachePoiVersion>
+        <apachePoiVersion>4.1.1</apachePoiVersion>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mavenShadePluginVersion>3.2.4</mavenShadePluginVersion>
         <metainfServicesVersion>1.8</metainfServicesVersion>
         <mysqlConnectorVersion>8.0.21</mysqlConnectorVersion>
-        <opennmsVersion>27.0.0</opennmsVersion>
+        <opennmsVersion>27.1.1</opennmsVersion>
         <postgresqlDriverVersion>42.2.18</postgresqlDriverVersion>
         <slf4jVersion>1.7.30</slf4jVersion>
         <updatePolicy>interval:60</updatePolicy>
@@ -208,8 +208,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${mavenCompilerPluginVersion}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -229,7 +229,7 @@
             </releases>
             <id>opennms-release</id>
             <name>OpenNMS Release Maven Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-release/</url>
+            <url>https://maven.opennms.org/content/groups/opennms.org-release/</url>
         </repository>
         <repository>
             <snapshots>
@@ -241,7 +241,7 @@
             </releases>
             <id>opennms-snapshot</id>
             <name>OpenNMS Snapshot Maven Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-snapshot/</url>
+            <url>https://maven.opennms.org/content/groups/opennms.org-snapshot/</url>
         </repository>
     </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jaxbApiVersion>2.3.1</jaxbApiVersion>
         <jaxbCoreVersion>2.3.0.1</jaxbCoreVersion>
         <jaxbImplVersion>2.3.1</jaxbImplVersion>
-        <jettyServerVersion>9.4.38.v20210224</jettyServerVersion>
+        <jettyServerVersion>10.0.10</jettyServerVersion>
         <junitVersion>4.13.1</junitVersion>
         <mavenAssemblyPluginVersion>3.3.0</mavenAssemblyPluginVersion>
         <mavenCompilerPluginVersion>3.8.1</mavenCompilerPluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <beanshellVersion>2.0b5</beanshellVersion>
         <chQosLogbackVersion>1.2.3</chQosLogbackVersion>
         <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
-        <commonsIoVersion>2.6</commonsIoVersion>
+        <commonsIoVersion>2.7</commonsIoVersion>
         <gparsVersion>1.2.1</gparsVersion>
         <groovyVersion>2.4.15</groovyVersion>
         <guavaVersion>[30.0-jre,)</guavaVersion>


### PR DESCRIPTION
Update dependencies to the latest available Horizon 27.1.1 Maven artifact. Merge Dependabot security updates and set the source and target compiler to Java 11.