### PR TITLE
PRIS-160: Allow CSV files as source for provisioning

### DIFF
--- a/docs/modules/sources/examples/csv/global.properties
+++ b/docs/modules/sources/examples/csv/global.properties
@@ -1,0 +1,8 @@
+### File: global.properties
+# Start web server
+# The web server listens on all interfaces and can be accessed on TCP port 8000
+# URL: http://${your-ip}:8000/requisitions/${name-requisition-cfg}
+
+driver = http
+host = 0.0.0.0
+port = 8000

--- a/docs/modules/sources/examples/csv/requisitions/myinventory-noheaders/myinventory-noheaders.csv
+++ b/docs/modules/sources/examples/csv/requisitions/myinventory-noheaders/myinventory-noheaders.csv
@@ -1,0 +1,6 @@
+bbone-gw1,10.0.23.1,P,ICMP;SNMP,Backbone
+bbone-gw2,10.0.23.2,P,ICMP;SNMP,Backbone
+rt-01,172.16.23.1,P,ICMP;SNMP,Office
+rt-02,172.16.23.2,P,ICMP;SNMP,Office
+rt-02,172.16.23.3,S,ICMP;StrafePing,
+rt-02,192.168.30.1,N,,

--- a/docs/modules/sources/examples/csv/requisitions/myinventory-noheaders/requisition.properties
+++ b/docs/modules/sources/examples/csv/requisitions/myinventory-noheaders/requisition.properties
@@ -1,0 +1,12 @@
+### File: myRouter/requisition.properties
+# This example imports devices from a spreadsheet
+# named "myRouter" from the myInventory.xls file
+# Path to the XLS fils is relative to
+# requisitions.properties
+source = xls
+source.file = ./myinventory-noheaders.csv
+
+source.org.opennms.pris.spreadsheet.fields=Node_Label,IP_Management,MgmtType_,svc_Forced,cat_Environment
+
+### default no-operation mapper
+mapper = echo

--- a/docs/modules/sources/examples/csv/requisitions/myinventory/myinventory.csv
+++ b/docs/modules/sources/examples/csv/requisitions/myinventory/myinventory.csv
@@ -1,0 +1,7 @@
+Node_Label,IP_Management,MgmtType_,svc_Forced,cat_Environment
+bbone-gw1,10.0.23.1,P,ICMP;SNMP,Backbone
+bbone-gw2,10.0.23.2,P,ICMP;SNMP,Backbone
+rt-01,172.16.23.1,P,ICMP;SNMP,Office
+rt-02,172.16.23.2,P,ICMP;SNMP,Office
+rt-02,172.16.23.3,S,ICMP;StrafePing,
+rt-02,192.168.30.1,N,,

--- a/docs/modules/sources/examples/csv/requisitions/myinventory/requisition.properties
+++ b/docs/modules/sources/examples/csv/requisitions/myinventory/requisition.properties
@@ -1,0 +1,10 @@
+### File: myRouter/requisition.properties
+# This example imports devices from a spreadsheet
+# named "myRouter" from the myInventory.xls file
+# Path to the XLS fils is relative to
+# requisitions.properties
+source = xls
+source.file = ./myinventory.csv
+
+### default no-operation mapper
+mapper = echo

--- a/docs/modules/sources/nav.adoc
+++ b/docs/modules/sources/nav.adoc
@@ -7,3 +7,4 @@
 * xref:ocs.adoc[]
 * xref:script.adoc[]
 * xref:xls.adoc[]
+* xref:csv.adoc[]

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -13,7 +13,7 @@ This lets {page-component-title} read CSV files that do not have a header.
 | `source.file`     | *        | Path of the CSV file to read relative to the `requisition.properties`.
 Note that the file name must end with `.csv`.
 | `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the CSV file is used as the column headers in the same way as in the XLS data source. 
-If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.
+If this property is set, the value of this field should be a comma-separated set of headers to use instead of using the first line of the CSV file.
 |===
 
 The structure of the CSV file should follow the same rules and use the same headers as in the XLS data source.

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -25,7 +25,7 @@ Node_Label,IP_Management,MgmtType_,svc_Forced,cat_Environment
 bbone-gw2,10.0.23.2,P,ICMP;SNMP,Backbone
 ```
 
-Example configuration for the requisition myinventory from a csv file myinventory.csv
+Example configuration for the requisition `myinventory` from a CSV file `myinventory.csv`:
 [source,bash]
 ----
 include::example$csv/requisitions/myinventory/requisition.properties[]

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -12,7 +12,7 @@ This lets {page-component-title} read CSV files that do not have a header.
 | `source`          | *        | Set `xls` to use the XLS source for this requisition.
 | `source.file`     | *        | Path of the CSV file to read relative to the `requisition.properties`.
 Note that the file name must end with `.csv`.
-| `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the csv file is used as the column headers in the same way as in the xls data source. 
+| `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the CSV file is used as the column headers in the same way as in the XLS data source. 
 If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.
 |===
 

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -9,7 +9,7 @@ This lets {page-component-title} read CSV files that do not have a header.
 [options="header",autowidth"]
 |===
 | Parameter         | Required | Description
-| `source`          | *        | set `xls` to use the XLS source for this requisition
+| `source`          | *        | Set `xls` to use the XLS source for this requisition.
 | `source.file`     | *        | path of the CSV file to read relative to the `requisition.properties`.Note the file name must end with `.csv`
 | `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the csv file is used as the column headers in the same way as in the xls data source. 
 If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -3,7 +3,7 @@
 The `xls` source can also create a requisition from a UTF-8 encoded, comma-separated variable (CSV) file if the given file name has the `.csv` suffix.
 
 In this case the first line of the CSV file should contain a comma-separated list of headers in the same way the spreadsheet should be configured in a normal XLS source. 
-Alternatively, a property can be set containing comma separated set of headers to be is used as the first line of the csv file.
+Alternatively, you can set a property containing a comma-separated set of headers to use as the first line of the CSV file.
 This allows csv file to be raad which don't have a header line.
 
 [options="header",autowidth"]

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -10,7 +10,8 @@ This lets {page-component-title} read CSV files that do not have a header.
 |===
 | Parameter         | Required | Description
 | `source`          | *        | Set `xls` to use the XLS source for this requisition.
-| `source.file`     | *        | path of the CSV file to read relative to the `requisition.properties`.Note the file name must end with `.csv`
+| `source.file`     | *        | Path of the CSV file to read relative to the `requisition.properties`.
+Note that the file name must end with `.csv`.
 | `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the csv file is used as the column headers in the same way as in the xls data source. 
 If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.
 |===

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -17,7 +17,7 @@ If this property is set, value of this field should be a comma separated set of 
 
 The structure of the CSV file should follow the same rules and use the same headers as in the XLS data source.
 
-However, any columns which would contain comma separated values in a spreadsheet must have the contents delineated using a semicolon ';' character rather than commas.
+However, any columns that would contain comma-separated values in a spreadsheet must have the contents delineated using a semicolon ';' character rather than commas.
 In the following example, the svc_Forced services ICMP;SNMP are separated using a semicolon.
 
 ```

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -31,7 +31,7 @@ Example configuration for the requisition `myinventory` from a CSV file `myinven
 include::example$csv/requisitions/myinventory/requisition.properties[]
 ----
 
-Example configuration for the requisition myinventory-noheaders from a csv file myinventory-noheaders.csv
+Example configuration for the requisition `myinventory-noheaders` from a CSV file `myinventory-noheaders.csv`:
 This has a source.org.opennms.pris.spreadsheet.fields property set.
 
 [source,bash]

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -1,6 +1,6 @@
 = CSV Source
 
-The `xls` source can also create a requisition from a UTF-8 encoded comma separated variable (CSV) file if the given file name has the `.csv` suffix.
+The `xls` source can also create a requisition from a UTF-8 encoded, comma-separated variable (CSV) file if the given file name has the `.csv` suffix.
 
 In this case the first line of the csv file should contain a comma separated list of headers in the same way the spreadsheet should be configured in a normal xls source. 
 Alternatively, a property can be set containing comma separated set of headers to be is used as the first line of the csv file.

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -32,7 +32,7 @@ include::example$csv/requisitions/myinventory/requisition.properties[]
 ----
 
 Example configuration for the requisition `myinventory-noheaders` from a CSV file `myinventory-noheaders.csv`:
-This has a source.org.opennms.pris.spreadsheet.fields property set.
+This example has a `source.org.opennms.pris.spreadsheet.fields` property set:
 
 [source,bash]
 ----

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -15,7 +15,7 @@ This lets {page-component-title} read CSV files that do not have a header.
 If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.
 |===
 
-The structure of the csv file should follow the same rules and use the same headers as in the xls data source.
+The structure of the CSV file should follow the same rules and use the same headers as in the XLS data source.
 
 However, any columns which would contain comma separated values in a spreadsheet must have the contents delineated using a semicolon ';' character rather than commas.
 In the following example, the svc_Forced services ICMP;SNMP are separated using a semicolon.

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -1,0 +1,40 @@
+= CSV Source
+
+The `xls` source can also create a requisition from a UTF-8 encoded comma separated variable (CSV) file if the given file name has the `.csv` suffix.
+
+In this case the first line of the csv file should contain a comma separated list of headers in the same way the spreadsheet should be configured in a normal xls source. 
+Alternatively, a property can be set containing comma separated set of headers to be is used as the first line of the csv file.
+This allows csv file to be raad which don't have a header line.
+
+[options="header",autowidth"]
+|===
+| Parameter         | Required | Description
+| `source`          | *        | set `xls` to use the XLS source for this requisition
+| `source.file`     | *        | path of the CSV file to read relative to the `requisition.properties`.Note the file name must end with `.csv`
+| `source.org.opennms.pris.spreadsheet.fields` |          | If this property is not present, the first line of the csv file is used as the column headers in the same way as in the xls data source. 
+If this property is set, value of this field should be a comma separated set of headers to be used instead of using the first line of the csv file.
+|===
+
+The structure of the csv file should follow the same rules and use the same headers as in the xls data source.
+
+However, any columns which would contain comma separated values in a spreadsheet must have the contents delineated using a semicolon ';' character rather than commas.
+In the following example, the svc_Forced services ICMP;SNMP are separated using a semicolon.
+
+```
+Node_Label,IP_Management,MgmtType_,svc_Forced,cat_Environment
+bbone-gw2,10.0.23.2,P,ICMP;SNMP,Backbone
+```
+
+Example configuration for the requisition myinventory from a csv file myinventory.csv
+[source,bash]
+----
+include::example$csv/requisitions/myinventory/requisition.properties[]
+----
+
+Example configuration for the requisition myinventory-noheaders from a csv file myinventory-noheaders.csv
+This has a source.org.opennms.pris.spreadsheet.fields property set.
+
+[source,bash]
+----
+include::example$csv/requisitions/myinventory-noheaders/requisition.properties[]
+----

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -2,7 +2,7 @@
 
 The `xls` source can also create a requisition from a UTF-8 encoded, comma-separated variable (CSV) file if the given file name has the `.csv` suffix.
 
-In this case the first line of the csv file should contain a comma separated list of headers in the same way the spreadsheet should be configured in a normal xls source. 
+In this case the first line of the CSV file should contain a comma-separated list of headers in the same way the spreadsheet should be configured in a normal XLS source. 
 Alternatively, a property can be set containing comma separated set of headers to be is used as the first line of the csv file.
 This allows csv file to be raad which don't have a header line.
 

--- a/docs/modules/sources/pages/csv.adoc
+++ b/docs/modules/sources/pages/csv.adoc
@@ -4,7 +4,7 @@ The `xls` source can also create a requisition from a UTF-8 encoded, comma-separ
 
 In this case the first line of the CSV file should contain a comma-separated list of headers in the same way the spreadsheet should be configured in a normal XLS source. 
 Alternatively, you can set a property containing a comma-separated set of headers to use as the first line of the CSV file.
-This allows csv file to be raad which don't have a header line.
+This lets {page-component-title} read CSV files that do not have a header.
 
 [options="header",autowidth"]
 |===

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
@@ -31,6 +31,11 @@
         <artifactId>poi-ooxml</artifactId>
         <version>${apachePoiVersion}</version>
 	</dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commonsLang3Version}</version>
+    </dependency>
         <!-- Tests -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
@@ -1,56 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.opennms</groupId>
-        <artifactId>opennms-pris-plugins</artifactId>
-        <version>BLEEDING</version>
-    </parent>
+   <parent>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-pris-plugins</artifactId>
+      <version>BLEEDING</version>
+   </parent>
 
-    <artifactId>opennms-pris-plugins-xls</artifactId>
-    <packaging>jar</packaging>
+   <artifactId>opennms-pris-plugins-xls</artifactId>
+   <packaging>jar</packaging>
 
-    <name>OpenNMS :: Provisioning Integration Server :: Plugins :: XLS</name>
+   <name>OpenNMS :: Provisioning Integration Server :: Plugins :: XLS</name>
 
-    <properties>
-        <apachePoiVersion>4.1.1</apachePoiVersion>
-    </properties>
+   <properties>
+      <apachePoiVersion>4.1.1</apachePoiVersion>
+   </properties>
 
-    <dependencies>
-        <!-- XLS -->
-    <dependency>
-        <groupId>org.apache.poi</groupId>
-        <artifactId>poi</artifactId>
-        <version>${apachePoiVersion}</version>
-    </dependency>
-	<dependency>
-        <groupId>org.apache.poi</groupId>
-        <artifactId>poi-ooxml</artifactId>
-        <version>${apachePoiVersion}</version>
-	</dependency>
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commonsLang3Version}</version>
-    </dependency>
-        <!-- Tests -->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>opennms-pris-api</artifactId>
-            <classifier>tests</classifier>
-        </dependency>
-    </dependencies>
+   <dependencies>
+      <!-- XLS -->
+      <dependency>
+         <groupId>org.apache.poi</groupId>
+         <artifactId>poi</artifactId>
+         <version>${apachePoiVersion}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.poi</groupId>
+         <artifactId>poi-ooxml</artifactId>
+         <version>${apachePoiVersion}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-lang3</artifactId>
+         <version>${commonsLang3Version}</version>
+      </dependency>
+      <!-- Tests -->
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>opennms-pris-api</artifactId>
+         <classifier>tests</classifier>
+      </dependency>
+   </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Build fat JAR -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+   <build>
+      <plugins>
+         <!-- Build fat JAR -->
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
@@ -33,7 +33,6 @@ public class XlsSourceTest {
 
 	@Test
 	public void testxlsSource() throws Exception {
-		System.out.println("**********testxlssource");
 		MockInstanceConfiguration config = new MockInstanceConfiguration("test");
 		config.set("encoding", "ISO-8859-1");
 		config.set("file", Paths.get("src/test/resources/test.xls"));
@@ -44,12 +43,11 @@ public class XlsSourceTest {
 
 		basicTest("test");
 
-		System.out.println("********** end testxlssource");
 	}
 
 	@Test
 	public void testCsvSource() throws Exception {
-		System.out.println("**********testcsvsource");
+
 		MockInstanceConfiguration config = new MockInstanceConfiguration("testcsv");
 		config.set("encoding", "ISO-8859-1");
 		config.set("file", Paths.get("src/test/resources/testcsv.csv"));
@@ -60,13 +58,10 @@ public class XlsSourceTest {
 
 		basicTest("testcsv");
 
-		System.out.println("**********end testcsvsource");
-
 	}
 
 	@Test
 	public void testCsvSourceNoHeader() throws Exception {
-		System.out.println("**********testcsvsource-noheader");
 		MockInstanceConfiguration config = new MockInstanceConfiguration("testcsv-noheaders");
 		config.set("encoding", "ISO-8859-1");
 		config.set("file", Paths.get("src/test/resources/testcsv-noheaders.csv"));
@@ -79,8 +74,6 @@ public class XlsSourceTest {
 		publishTestRequisitionAndSheet("testcsv-noheaders");
 
 		basicTest("testcsv-noheaders");
-
-		System.out.println("**********end testcsvsource-noheader");
 
 	}
 

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
@@ -1,5 +1,7 @@
 package org.opennms.opennms.pris.plugins.xls.source;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.nio.file.Paths;
 
 import static org.hamcrest.Matchers.contains;
@@ -7,6 +9,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.pris.api.MockInstanceConfiguration;
@@ -20,69 +23,151 @@ import org.opennms.pris.model.RequisitionMonitoredService;
 import org.opennms.pris.model.RequisitionNode;
 import org.opennms.pris.util.RequisitionUtils;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
 public class XlsSourceTest {
 
-    private XlsSource xlsSource;
+	private XlsSource xlsSource;
 
-    @Before
-    public void setUp() {
-        MockInstanceConfiguration config = new MockInstanceConfiguration("test");
-        config.set("encoding", "ISO-8859-1");
-        config.set("file", Paths.get("src/test/resources/test.xls"));
+	@Test
+	public void testxlsSource() throws Exception {
+		System.out.println("**********testxlssource");
+		MockInstanceConfiguration config = new MockInstanceConfiguration("test");
+		config.set("encoding", "ISO-8859-1");
+		config.set("file", Paths.get("src/test/resources/test.xls"));
 
-        xlsSource = new XlsSource(config);
-    }
+		xlsSource = new XlsSource(config);
 
-    @Test
-    public void basicTest() throws Exception {
-        Requisition resultRequisition = (Requisition) xlsSource.dump();
-        
-        assertEquals(resultRequisition.getForeignSource(), "test");
-        assertEquals(2, resultRequisition.getNodes().size());
-        
-        RequisitionNode resultNode = resultRequisition.getNodes().get(0);
-        assertEquals("TestNode", resultNode.getNodeLabel());
-        assertEquals("TestNode", resultNode.getForeignId());
-        assertEquals("Test-Parent-Foreign-Source", resultNode.getParentForeignSource());
-        assertEquals("Test-Parent-Foreign-Id", resultNode.getParentForeignId());
-        assertEquals("Test-Parent-Node-Label", resultNode.getParentNodeLabel());
-        assertEquals("Test-Location", resultNode.getLocation());
-        
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.vendor.name).getValue(), "Vater");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.city.name).getValue(), "Braunschweig");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.vendorPhone.name).getValue(), "123");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.address1.name).getValue(), "Wilhelmstraße 30");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.description.name).getValue(), "POB: Johann Carl Friedrich Gauß");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.comment.name).getValue(), "Died in Göttingen");
-        
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.latitude.name).getValue(), "54.9633229");
-        assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.longitude.name).getValue(), "1");
-        
-        RequisitionInterface resultInterface = RequisitionUtils.findInterface(resultNode, "1.2.3.4");
-        assertEquals(PrimaryType.PRIMARY, resultInterface.getSnmpPrimary());
-        assertEquals(1, resultInterface.getStatus());
-        
-        RequisitionMonitoredService resultService = RequisitionUtils.findMonitoredService(resultInterface, "Test");
-        assertEquals("Test", resultService.getServiceName());
-        
-        RequisitionCategory findCategory = RequisitionUtils.findCategory(resultNode, "Test");
-        assertEquals("Test", findCategory.getName());
+		publishTestRequisitionAndSheet("test");
 
-        assertThat(resultNode.getMetaDatas(), containsInAnyOrder(
-                new MetaData("requisition", "KeyWithoutContext", "Foo"),
-                new MetaData("Context", "KeyWithContext", "Bar")));
-    }
+		basicTest("test");
 
-    @Test
-    public void getNodeWithMultipleIpInterfaces() throws Exception {
-        Requisition resultRequisition = (Requisition) xlsSource.dump();
-        assertEquals(resultRequisition.getForeignSource(), "test");
-        RequisitionNode resultNode = resultRequisition.getNodes().get(1);
-        assertEquals(resultNode.getInterfaces().size(), 2);
-        assertEquals(resultNode.getNodeLabel(), "Node2Ips");
-        assertEquals(resultNode.getInterfaces().get(0).getIpAddr(),"23.23.23.23");
-        assertEquals(resultNode.getInterfaces().get(0).getSnmpPrimary(),"P");
-        assertEquals(resultNode.getInterfaces().get(1).getIpAddr(),"42.42.42.42");
-        assertEquals(resultNode.getInterfaces().get(1).getSnmpPrimary(),"S");
-    }
+		System.out.println("********** end testxlssource");
+	}
+
+	@Test
+	public void testCsvSource() throws Exception {
+		System.out.println("**********testcsvsource");
+		MockInstanceConfiguration config = new MockInstanceConfiguration("testcsv");
+		config.set("encoding", "ISO-8859-1");
+		config.set("file", Paths.get("src/test/resources/testcsv.csv"));
+
+		xlsSource = new XlsSource(config);
+
+		publishTestRequisitionAndSheet("testcsv");
+
+		basicTest("testcsv");
+
+		System.out.println("**********end testcsvsource");
+
+	}
+
+	@Test
+	public void testCsvSourceNoHeader() throws Exception {
+		System.out.println("**********testcsvsource-noheader");
+		MockInstanceConfiguration config = new MockInstanceConfiguration("testcsv-noheaders");
+		config.set("encoding", "ISO-8859-1");
+		config.set("file", Paths.get("src/test/resources/testcsv-noheaders.csv"));
+
+		config.set("org.opennms.pris.spreadsheet.fields",
+				"Parent_Foreign_Source,Parent_Foreign_ID,Parent_Node_Label,ID_,Node_Label,Location,Asset_Description,IP_Address,MgmtType_For_SNMP,InterfaceStatus,Cat_Test,Svc_Test,Asset_City,Asset_Address1,Asset_Address2,Asset_Comment,Asset_Vendor,Asset_VendorPhone,MetaData_KeyWithoutContext,MetaData_Context:KeyWithContext,Asset_latitude,Asset_longitude");
+
+		xlsSource = new XlsSource(config);
+
+		publishTestRequisitionAndSheet("testcsv-noheaders");
+
+		basicTest("testcsv-noheaders");
+
+		System.out.println("**********end testcsvsource-noheader");
+
+	}
+
+	// test method used by xls and csv tests
+	public void basicTest(String foreignSource) throws Exception {
+		Requisition resultRequisition = (Requisition) xlsSource.dump();
+
+		assertEquals(resultRequisition.getForeignSource(), foreignSource);
+		assertEquals(2, resultRequisition.getNodes().size());
+
+		RequisitionNode resultNode = resultRequisition.getNodes().get(0);
+		assertEquals("TestNode", resultNode.getNodeLabel());
+		assertEquals("TestNode", resultNode.getForeignId());
+		assertEquals("Test-Parent-Foreign-Source", resultNode.getParentForeignSource());
+		assertEquals("Test-Parent-Foreign-Id", resultNode.getParentForeignId());
+		assertEquals("Test-Parent-Node-Label", resultNode.getParentNodeLabel());
+		assertEquals("Test-Location", resultNode.getLocation());
+
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.vendor.name).getValue(), "Vater");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.city.name).getValue(), "Braunschweig");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.vendorPhone.name).getValue(), "123");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.address1.name).getValue(), "Wilhelmstraße 30");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.description.name).getValue(),
+				"POB: Johann Carl Friedrich Gauß");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.comment.name).getValue(), "Died in Göttingen");
+
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.latitude.name).getValue(), "54.9633229");
+		assertEquals(RequisitionUtils.findAsset(resultNode, AssetField.longitude.name).getValue(), "1");
+
+		RequisitionInterface resultInterface = RequisitionUtils.findInterface(resultNode, "1.2.3.4");
+		assertEquals(PrimaryType.PRIMARY, resultInterface.getSnmpPrimary());
+		assertEquals(1, resultInterface.getStatus());
+
+		RequisitionMonitoredService resultService = RequisitionUtils.findMonitoredService(resultInterface, "Test");
+		assertEquals("Test", resultService.getServiceName());
+
+		RequisitionCategory findCategory = RequisitionUtils.findCategory(resultNode, "Test");
+		assertEquals("Test", findCategory.getName());
+
+		assertThat(resultNode.getMetaDatas(),
+				containsInAnyOrder(new MetaData("requisition", "KeyWithoutContext", "Foo"),
+						new MetaData("Context", "KeyWithContext", "Bar")));
+	}
+
+	// test method used by xls and csv tests
+	public void getNodeWithMultipleIpInterfaces(String foreignSource) throws Exception {
+		Requisition resultRequisition = (Requisition) xlsSource.dump();
+		assertEquals(resultRequisition.getForeignSource(), foreignSource);
+		RequisitionNode resultNode = resultRequisition.getNodes().get(1);
+		assertEquals(resultNode.getInterfaces().size(), 2);
+		assertEquals(resultNode.getNodeLabel(), "Node2Ips");
+		assertEquals(resultNode.getInterfaces().get(0).getIpAddr(), "23.23.23.23");
+		assertEquals(resultNode.getInterfaces().get(0).getSnmpPrimary(), "P");
+		assertEquals(resultNode.getInterfaces().get(1).getIpAddr(), "42.42.42.42");
+		assertEquals(resultNode.getInterfaces().get(1).getSnmpPrimary(), "S");
+	}
+
+	public void publishTestRequisitionAndSheet(String name) {
+
+		// print out parsed spreadsheet
+		File xls = new File(xlsSource.getXlsFile());
+		Workbook workbook = xlsSource.getWorkbook(xls);
+		File xlsFile = new File("target/" + name + ".xls");
+		xlsFile.delete();
+		try (FileOutputStream outputStream = new FileOutputStream(xlsFile)) {
+			workbook.write(outputStream);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+
+		// print out xml requisition
+
+		File csvFile = new File("target/" + name + ".xml");
+		csvFile.delete();
+		try (FileOutputStream outputStream = new FileOutputStream(csvFile)) {
+
+			Requisition resultRequisition = (Requisition) xlsSource.dump();
+
+			JAXBContext jc = JAXBContext.newInstance("org.opennms.pris.model");
+			Marshaller marshaller = jc.createMarshaller();
+			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+			marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
+			marshaller.marshal(resultRequisition, outputStream);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+	}
+
 }

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/resources/testcsv-noheaders.csv
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/resources/testcsv-noheaders.csv
@@ -1,0 +1,3 @@
+Test-Parent-Foreign-Source,Test-Parent-Foreign-Id,Test-Parent-Node-Label,TestNode,TestNode,Test-Location,POB: Johann Carl Friedrich Gauß,1.2.3.4,P,1,Test,Test,Braunschweig,Wilhelmstraße 30,,Died in Göttingen,Vater,123,Foo,Bar,54.9633229,1
+,,,,Node2Ips,Node2Ips-Location,,23.23.23.23,P,,,,,,,,,,,,,
+,,,,Node2Ips,,,42.42.42.42,S,,,,,,,,,,,,,

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/resources/testcsv.csv
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/resources/testcsv.csv
@@ -1,0 +1,4 @@
+Parent_Foreign_Source,Parent_Foreign_ID,Parent_Node_Label,ID_,Node_Label,Location,Asset_Description,IP_Address,MgmtType_For_SNMP,InterfaceStatus,Cat_Test,Svc_Test,Asset_City,Asset_Address1,Asset_Address2,Asset_Comment,Asset_Vendor,Asset_VendorPhone,MetaData_KeyWithoutContext,MetaData_Context:KeyWithContext,Asset_latitude,Asset_longitude
+Test-Parent-Foreign-Source,Test-Parent-Foreign-Id,Test-Parent-Node-Label,TestNode,TestNode,Test-Location,POB: Johann Carl Friedrich Gauß,1.2.3.4,P,1,Test,Test,Braunschweig,Wilhelmstraße 30,,Died in Göttingen,Vater,123,Foo,Bar,54.9633229,1
+,,,,Node2Ips,Node2Ips-Location,,23.23.23.23,P,,,,,,,,,,,,,
+,,,,Node2Ips,,,42.42.42.42,S,,,,,,,,,,,,,

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <chQosLogbackVersion>1.2.3</chQosLogbackVersion>
         <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
         <commonsIoVersion>2.7</commonsIoVersion>
+        <commonsLang3Version>3.12.0</commonsLang3Version>
         <gparsVersion>1.2.1</gparsVersion>
         <groovyVersion>2.4.15</groovyVersion>
         <guavaVersion>[30.0-jre,)</guavaVersion>


### PR DESCRIPTION
https://opennms.atlassian.net/browse/PRIS-160 

This enhancement allows comma separated variable files to be used with the same fields as an xls spreadsheet in order to create a requisition. Internally the csv file is turned into an apache poi  spreadsheet and parsed using the existing code. 

Extra documentation and examples have also been provided. 