### PR TITLE
PRIS-119: build javadoc, and publish to Github Pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ executors:
   go-executor:
     docker:
       - image: circleci/golang
+  simple-executor:
+    docker:
+      - image: cimg/base:current
 
 commands:
   dockerhub-login:
@@ -26,7 +29,10 @@ commands:
 workflows:
   build:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: gh-pages
       - generate-docs:
           requires:
             - build
@@ -55,6 +61,15 @@ workflows:
             branches:
               only:
                 - /^release-.*/
+          requires:
+            - smoke-tests
+      - publish-javadoc:
+          context:
+            - "github-releases"
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - smoke-tests
 
@@ -252,3 +267,34 @@ jobs:
               cp opennms-pris-dist/target/opennms-pris-release-archive.tar.gz github-latest/opennms-pris-release-$(cat version.txt).tar.gz
               cp opennms-pris-dist/target/opennms-pris-release-archive.zip github-latest/opennms-pris-release-$(cat version.txt).zip
               ghr -r ${CIRCLE_PROJECT_REPONAME} $(cat version.txt) github-latest
+
+  publish-javadoc:
+      executor: simple-executor
+      steps:
+        - attach_workspace:
+            at: ~/
+        - add_ssh_keys:
+            fingerprints:
+              - "80:24:47:19:df:7b:f3:bf:8a:4d:45:c1:89:88:29:4c"
+        - run:
+            name: clone gh-pages branch
+            command: |
+              cd ~/project
+              install -d -m 700 ~/.ssh
+              curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
+              git clone --filter=tree:0 --branch gh-pages git@github.com:OpenNMS/opennms-provisioning-integration-server gh-pages
+        - run:
+            name: publish updated javadocs
+            command: |
+              cd ~/project/gh-pages
+              rm -rf *
+              unzip ../target/*-javadoc.jar
+              git add -A .
+              git config user.email "cicd-system@opennms.com"
+              git config user.name "CI/CD System"
+              git commit -m 'publish latest API docs'
+        - run:
+            name: push to gh-pages
+            command: |
+              cd ~/project/gh-pages
+              git push --no-verify origin gh-pages:gh-pages

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Configuration.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Configuration.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * Container for a configuration.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public interface Configuration {
 
@@ -190,7 +190,7 @@ public interface Configuration {
      * behavior of the iterator's {@code remove()} method is specific to a
      * concrete implementation. It <em>may</em> remove the corresponding
      * property from the configuration, but this is not guaranteed. In any case
-     * it is no replacement for calling {@link #clearProperty(String)} for this
+     * it is no replacement for calling {@code clearProperty(String)} for this
      * property. So it is highly recommended to avoid using the iterator's
      * {@code remove()} method.
      *

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/InstanceConfiguration.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/InstanceConfiguration.java
@@ -28,7 +28,7 @@ package org.opennms.pris.api;
 /**
  * Container for an instance configuration.
  * 
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public interface InstanceConfiguration extends Configuration {
    

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Mapper.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Mapper.java
@@ -26,12 +26,12 @@ import org.opennms.pris.model.Requisition;
  *
  * The data loaded by a source implementation are passed the the map function and a new requisition must be returned.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public interface Mapper {
 
     /**
-     * Factory interface for creating {@link Mapper}s.
+     * Factory interface for creating Mappers.
      */
     interface Factory {
 

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Source.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Source.java
@@ -28,7 +28,7 @@ package org.opennms.pris.api;
 /**
  * A source for information used to create a requisition.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public interface Source {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/ConfigManager.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/ConfigManager.java
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License along with OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  ******************************************************************************
  */
@@ -45,7 +45,7 @@ import org.opennms.pris.config.InstanceApacheConfiguration;
  *
  * The instance configurations are loaded from sub-folders relative to the configuration base path where the instance name in the folder name.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class ConfigManager {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/RequisitionGenerator.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/RequisitionGenerator.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License along with
  * OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  ******************************************************************************
  */
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * The source and mapping implementation to use is loaded from the configuration
  * of the instance for which the requisition is created.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class RequisitionGenerator {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/Starter.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/Starter.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License along with
  * OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  ******************************************************************************
  */
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  *
  * The main class loads a driver for the configured working and runs it.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class Starter {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/Driver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/Driver.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License along with
  * OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  ******************************************************************************
  */
@@ -33,7 +33,7 @@ import org.opennms.pris.api.Configuration;
  *
  * The driver runs a working mode.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public interface Driver {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License along with
  * OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  * *****************************************************************************
  */
@@ -46,7 +46,7 @@ import org.opennms.pris.api.Configuration;
  * The instance name is passed as an parameter. The created requisition is
  * printed to standard output or to a given file name.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class FileDriver implements Driver {
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License along with
  * OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  * *****************************************************************************
  */
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * used as instance name and the the returned result is the XML serialized
  * requisition.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class HttpServerDriver implements Driver {
 

--- a/opennms-pris-plugins/opennms-pris-plugins-script/src/main/java/org/opennms/opennms/pris/plugins/script/mapper/ScriptMapper.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-script/src/main/java/org/opennms/opennms/pris/plugins/script/mapper/ScriptMapper.java
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License along with OpenNMS(R). If not, see: http://www.gnu.org/licenses/
  *
- * For more information contact: OpenNMS(R) Licensing <license@opennms.org>
+ * For more information contact: OpenNMS(R) Licensing &lt;license@opennms.org&gt;
  * http://www.opennms.org/ http://www.opennms.com/
  ******************************************************************************
  */
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * The mapper implementation creates a requisition by passing the data from the source to a script. The Script has to create the requisition.
  *
- * @author Dustin Frisch <fooker@lab.sh>
+ * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class ScriptMapper implements Mapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScriptMapper.class);

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,27 @@
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>aggregate-docs</id>
+                        <inherited>false</inherited>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>aggregate-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I temporarily enabled gh-pages pushing in the branch long enough to make it pass, you can see it running [here](https://app.circleci.com/pipelines/github/OpenNMS/opennms-provisioning-integration-server/199/workflows/05f00f51-3c97-431f-ac4c-b1a56abe0513/jobs/1236). (It's turned off again for this final PR merge, should only happen in `master` now.)

Published docs end up at: http://opennms.github.io/opennms-provisioning-integration-server/

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/PRIS-119

