### PR TITLE
PRIS-178: build: make run goal and changeversion version.txt update (merge after #167)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Copyright 2026 The OpenNMS Group, Inc.
 # Created by Ronny Trommer <ronny@opennms.com>
 ##
-.PHONY: help all deps-build compile package deps-docs deps-docs-docker deps-oci docs docs-check docs-docker oci-stage oci smoke-test clean clean-docs clean-docs-cache clean-all
+.PHONY: help all deps-build compile package run deps-docs deps-docs-docker deps-oci docs docs-check docs-docker oci-stage oci smoke-test clean clean-docs clean-docs-cache clean-all
 
 .DEFAULT_GOAL := help
 
@@ -16,6 +16,7 @@ SITE_FILE            := antora-playbook-local.yml
 IMAGE                ?= pris
 VERSION              ?= $(shell cat version.txt)
 RELEASE_ARCHIVE      := opennms-pris-dist/target/opennms-pris-release-archive.tar.gz
+RUN_DIR              := opennms-pris-dist/target/run
 
 help: ## Show this help with all build goals
 	@echo ""
@@ -42,6 +43,14 @@ compile: ## Compile the project and run the test suite
 package: ## Package the release archives in tar.gz and zip format
 	@echo "Maven package ..."
 	mvn package -DskipTests
+
+run: deps-build package ## Build from source and start PRIS in the foreground on http://localhost:8000
+	@echo "Extract release archive to $(RUN_DIR) ..."
+	@rm -rf $(RUN_DIR)
+	@mkdir -p $(RUN_DIR)
+	@tar -xzf $(RELEASE_ARCHIVE) -C $(RUN_DIR)
+	@echo "Starting PRIS on http://localhost:8000 (press Ctrl-C to stop) ..."
+	cd $(RUN_DIR)/opennms-pris && java $${JAVA_OPTS:-} -cp "./lib/*:./opennms-pris.jar" org.opennms.pris.Starter
 
 deps-docs:
 	@command -v antora

--- a/bin/changeversion.sh
+++ b/bin/changeversion.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Script changes the pom.xml files in the current project.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Script changes the pom.xml files, docs and version.txt in the current project.
 #
 # Usage example:
 #   changeversion.sh -o 1.0.4-SNAPSHOT -n 1.0.5-SNAPSHOT
@@ -61,3 +63,7 @@ for i in $(find ${CWD}/docs -name "antora.yml"); do
   cat ${i} | sed -e "s/${OLD_VERSION}/${NEW_VERSION}/g" | sed -e "s/prerelease: true/prerelease: false/g" > ${i}.new;
   mv ${i}.new ${i};
 done
+
+# Replace version number in the version.txt file
+cat ${CWD}/version.txt | sed -e "s/${OLD_VERSION}/${NEW_VERSION}/g" > ${CWD}/version.txt.new;
+mv ${CWD}/version.txt.new ${CWD}/version.txt;


### PR DESCRIPTION
**Merge order: 3 of 5 — merge after #166 and the xls-fixes PR.**

Stacked series; the diff collapses to just these commits once the earlier PRs merge.

## Summary
- **`make run`** — build from source and start PRIS in the foreground on http://localhost:8000.
- **`changeversion.sh`** — also rewrite `version.txt` so a version bump is a single command.

## Order
1. #166 → 2. xls fixes → 3. **this PR** → 4. build warnings → 5. docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)