### PR TITLE
PRIS-179: build: eliminate build warnings (merge after #167, #168)

### DIFF
--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Configuration.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Configuration.java
@@ -201,6 +201,11 @@ public interface Configuration {
      */
     Iterator<String> getKeys();
 
-    
+    /**
+     * Adds a property to the configuration.
+     *
+     * @param key the key of the property to add
+     * @param string the value of the property to add
+     */
     void addProperty(String key, String string);
 }

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Mapper.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Mapper.java
@@ -72,7 +72,7 @@ public interface Mapper {
      *
      * @return the mapped requisition
      *
-     * @throws Exception
+     * @throws Exception if the data cannot be mapped to a requisition
      */
     Requisition map(final Object data,
                     final Requisition requisition) throws Exception;

--- a/opennms-pris-api/src/main/java/org/opennms/pris/api/Source.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/api/Source.java
@@ -65,7 +65,7 @@ public interface Source {
      *
      * @return the loaded information
      *
-     * @throws Exception
+     * @throws Exception if the information cannot be loaded
      */
     Object dump() throws Exception;
 }

--- a/opennms-pris-api/src/main/java/org/opennms/pris/util/AssetUtils.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/util/AssetUtils.java
@@ -28,11 +28,25 @@
 
 package org.opennms.pris.util;
 
+/**
+ * Utility methods for normalizing asset field values before they are stored in
+ * a requisition.
+ */
 public class AssetUtils {
 
     private AssetUtils() {
     }
 
+    /**
+     * Cleans up an asset string by stripping trademark markers, abbreviating
+     * common vendor and operating-system names, collapsing runs of whitespace
+     * and truncating the result to a maximum length.
+     *
+     * @param assetString the raw asset value, may be {@code null}
+     * @param maxSize the maximum number of characters to keep
+     * @return the cleaned value, or an empty string if {@code assetString} is
+     *         {@code null}
+     */
     public static String assetStringCleaner(final String assetString,
                                             final Integer maxSize) {
         String result = "";

--- a/opennms-pris-api/src/main/java/org/opennms/pris/util/InterfaceUtils.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/util/InterfaceUtils.java
@@ -39,18 +39,33 @@ import org.slf4j.LoggerFactory;
 import org.opennms.integration.api.utils.IPLike;
 import org.opennms.pris.api.InstanceConfiguration;
 
+/**
+ * Maintains IP black- and white-lists and matches IP addresses against them
+ * using IPLike patterns.
+ */
 public class InterfaceUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(InterfaceUtils.class);
-    
+
     private List<String> ipBlackList = new ArrayList<>();
     private List<String> ipWhiteList = new ArrayList<>();
 
     private final InstanceConfiguration config;
-    
+
+    /**
+     * Creates interface utilities bound to the given instance configuration.
+     *
+     * @param config the configuration of the requisition instance
+     */
     public InterfaceUtils(final InstanceConfiguration config) {
         this.config = config;
     }
 
+    /**
+     * Checks whether the given IP address matches any entry on the black-list.
+     *
+     * @param ipAddress the IP address to test
+     * @return {@code true} if the address matches a black-list entry
+     */
     public Boolean isIpBlackListed(String ipAddress) {
         for (String blackedIp : ipBlackList) {
             if (IPLike.matches(ipAddress, blackedIp)) {
@@ -63,6 +78,12 @@ public class InterfaceUtils {
         return false;
     }
 
+    /**
+     * Checks whether the given IP address matches any entry on the white-list.
+     *
+     * @param ipAddress the IP address to test
+     * @return {@code true} if the address matches a white-list entry
+     */
     public Boolean isIpWhiteListed(String ipAddress) {
         for (String whiteIp : ipWhiteList) {
             if (IPLike.matches(ipAddress, whiteIp)) {
@@ -75,6 +96,12 @@ public class InterfaceUtils {
         return false;
     }
 
+    /**
+     * Adds an IPLike pattern to the white-list. Entries with invalid syntax are
+     * rejected and logged rather than added.
+     *
+     * @param ip the IPLike pattern to add
+     */
     public void addIpWhite(String ip) {
         try {
             //This check forces valid IPLike syntax
@@ -85,6 +112,12 @@ public class InterfaceUtils {
         }
     }
 
+    /**
+     * Adds an IPLike pattern to the black-list. Entries with invalid syntax are
+     * rejected and logged rather than added.
+     *
+     * @param ip the IPLike pattern to add
+     */
     public void addIpBlack(String ip) {
         try {
             //This check forces valid IPLike syntax
@@ -95,6 +128,11 @@ public class InterfaceUtils {
         }
     }
 
+    /**
+     * Loads the black- and white-lists from the {@code blackList.properties} and
+     * {@code whiteList.properties} files in the working directory, falling back
+     * to empty lists if the files cannot be read.
+     */
     public void initListsFromConfigs() {
         try {
             List<String> rawBlackedList = Files.readAllLines(Paths.get("./", "blackList.properties"), Charset.forName("UTF-8"));

--- a/opennms-pris-api/src/main/java/org/opennms/pris/util/RequisitionUtils.java
+++ b/opennms-pris-api/src/main/java/org/opennms/pris/util/RequisitionUtils.java
@@ -38,11 +38,21 @@ import org.opennms.pris.model.RequisitionInterface;
 import org.opennms.pris.model.RequisitionMonitoredService;
 import org.opennms.pris.model.RequisitionNode;
 
+/**
+ * Utility methods for looking up elements within a requisition or its nodes.
+ */
 public class RequisitionUtils {
 
     private RequisitionUtils() {
     }
 
+    /**
+     * Finds the node with the given foreign ID.
+     *
+     * @param requisition the requisition to search
+     * @param foreignId the foreign ID to match
+     * @return the matching node, or {@code null} if none matches
+     */
     public static RequisitionNode findNode(final Requisition requisition,
             final String foreignId) {
         for (final RequisitionNode node : requisition.getNodes()) {
@@ -54,6 +64,13 @@ public class RequisitionUtils {
         return null;
     }
 
+    /**
+     * Finds the interface on the given node with the given IP address.
+     *
+     * @param node the node to search
+     * @param ipAddress the IP address to match
+     * @return the matching interface, or {@code null} if none matches
+     */
     public static RequisitionInterface findInterface(final RequisitionNode node,
             final String ipAddress) {
         for (final RequisitionInterface _interface : node.getInterfaces()) {
@@ -65,6 +82,13 @@ public class RequisitionUtils {
         return null;
     }
 
+    /**
+     * Finds the category on the given node with the given name.
+     *
+     * @param node the node to search
+     * @param categoryName the category name to match
+     * @return the matching category, or {@code null} if none matches
+     */
     public static RequisitionCategory findCategory(final RequisitionNode node,
             final String categoryName) {
         for (final RequisitionCategory category : node.getCategories()) {
@@ -76,6 +100,15 @@ public class RequisitionUtils {
         return null;
     }
 
+    /**
+     * Determines whether the given node carries the given category.
+     *
+     * @param node the node to search
+     * @param categoryName the category name to match
+     * @param ignoreCase whether a case-insensitive match is sufficient; when
+     *        {@code false} the names must match exactly
+     * @return {@code true} if a matching category exists
+     */
     public static Boolean hasCategory(final RequisitionNode node, final String categoryName, final Boolean ignoreCase) {
         for (final RequisitionCategory category : node.getCategories()) {
             if (Objects.equals(category.getName().toLowerCase(), categoryName.toLowerCase())) {
@@ -91,6 +124,13 @@ public class RequisitionUtils {
         return false;
     }
 
+    /**
+     * Finds the asset on the given node with the given name.
+     *
+     * @param node the node to search
+     * @param assetName the asset name to match
+     * @return the matching asset, or {@code null} if none matches
+     */
     public static RequisitionAsset findAsset(final RequisitionNode node,
             final String assetName) {
         for (final RequisitionAsset asset : node.getAssets()) {
@@ -102,6 +142,14 @@ public class RequisitionUtils {
         return null;
     }
 
+    /**
+     * Finds the meta-data entry on the given node with the given context and key.
+     *
+     * @param node the node to search
+     * @param context the meta-data context to match
+     * @param key the meta-data key to match
+     * @return the matching meta-data entry, or {@code null} if none matches
+     */
     public static MetaData findMetaData(final RequisitionNode node,
                                         final String context, final String key) {
         for (final MetaData metaData : node.getMetaDatas()) {
@@ -113,6 +161,13 @@ public class RequisitionUtils {
         return null;
     }
 
+    /**
+     * Finds the monitored service on the given interface with the given name.
+     *
+     * @param _interface the interface to search
+     * @param serviceName the service name to match
+     * @return the matching monitored service, or {@code null} if none matches
+     */
     public static RequisitionMonitoredService findMonitoredService(final RequisitionInterface _interface,
             final String serviceName) {
         for (final RequisitionMonitoredService monitoredService : _interface.getMonitoredServices()) {

--- a/opennms-pris-api/src/test/java/org/opennms/pris/api/MockInstanceConfiguration.java
+++ b/opennms-pris-api/src/test/java/org/opennms/pris/api/MockInstanceConfiguration.java
@@ -65,16 +65,18 @@ public class MockInstanceConfiguration implements InstanceConfiguration {
         return this.values.containsKey(key);
     }
     
+    @SuppressWarnings("unchecked")
     private <T> T get(final String key) {
         return (T) this.values.get(key);
     }
-    
+
+    @SuppressWarnings("unchecked")
     private <T> T get(final String key,
                       final T defaultValue) {
         if (!this.values.containsKey(key)) {
             return defaultValue;
         }
-        
+
         return (T) this.values.get(key);
     }
     

--- a/opennms-pris-dist/src/assembly/assembly.xml
+++ b/opennms-pris-dist/src/assembly/assembly.xml
@@ -47,6 +47,9 @@
     <dependencySets>
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
+            <!-- This is a pom-packaging module with no artifact of its own; do not
+                 try to include it (avoids the "Cannot include project artifact" warning). -->
+            <useProjectArtifact>false</useProjectArtifact>
             <includes>
                 <include>${project.groupId}:opennms-pris-plugins-*:jar:shaded</include>
             </includes>

--- a/opennms-pris-plugins/opennms-pris-plugins-jdbc/src/test/java/org/opennms/opennms/pris/plugins/jdbc/source/JdbcSourceTest.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-jdbc/src/test/java/org/opennms/opennms/pris/plugins/jdbc/source/JdbcSourceTest.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -155,8 +156,8 @@ public class JdbcSourceTest {
         final RequisitionNode node2 = requisition.getNodes().stream().filter(n -> n.getForeignId().equals("2")).findFirst().get();
         final RequisitionNode node3 = requisition.getNodes().stream().filter(n -> n.getForeignId().equals("3")).findFirst().get();
 
-        Assert.assertThat(node1.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo1"), new MetaData("Context", "keyWithContext", "Bar1")));
-        Assert.assertThat(node2.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo2"), new MetaData("Context", "keyWithContext", "Bar2")));
-        Assert.assertThat(node3.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo3"), new MetaData("Context", "keyWithContext", "Bar3")));
+        MatcherAssert.assertThat(node1.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo1"), new MetaData("Context", "keyWithContext", "Bar1")));
+        MatcherAssert.assertThat(node2.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo2"), new MetaData("Context", "keyWithContext", "Bar2")));
+        MatcherAssert.assertThat(node3.getMetaDatas(), Matchers.containsInAnyOrder(new MetaData("requisition", "keyWithoutContext", "Foo3"), new MetaData("Context", "keyWithContext", "Bar3")));
     }
 }

--- a/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
@@ -27,6 +27,18 @@
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <version>2.3.3</version>
+            <exclusions>
+                <!--
+                    The API-only jakarta.activation-api ships the same classes as the
+                    com.sun.activation:jakarta.activation reference implementation pulled in
+                    by jaxws-rt. Drop the redundant API jar to avoid duplicate classes in
+                    the shaded uber-jar.
+                -->
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/main/java/org/opennms/opennms/pris/plugins/xls/source/exceptions/InvalidInterfaceException.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/main/java/org/opennms/opennms/pris/plugins/xls/source/exceptions/InvalidInterfaceException.java
@@ -30,6 +30,8 @@ package org.opennms.opennms.pris.plugins.xls.source.exceptions;
 
 public class InvalidInterfaceException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     public InvalidInterfaceException(String string) {
         super(string);
     }

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/main/java/org/opennms/opennms/pris/plugins/xls/source/exceptions/MissingRequiredColumnHeaderException.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/main/java/org/opennms/opennms/pris/plugins/xls/source/exceptions/MissingRequiredColumnHeaderException.java
@@ -30,6 +30,8 @@ package org.opennms.opennms.pris.plugins.xls.source.exceptions;
 
 public class MissingRequiredColumnHeaderException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     public MissingRequiredColumnHeaderException(String columnName) {
         this(columnName, null);
     }

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/src/test/java/org/opennms/opennms/pris/plugins/xls/source/XlsSourceTest.java
@@ -35,8 +35,8 @@ import java.nio.file.Paths;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.apache.poi.ss.usermodel.Row;

--- a/opennms-pris-plugins/pom.xml
+++ b/opennms-pris-plugins/pom.xml
@@ -74,8 +74,33 @@
 
                         <shadedArtifactAttached>true</shadedArtifactAttached>
 
+                        <!--
+                            Drop resources that multiple dependencies duplicate. module-info
+                            descriptors are meaningless on the shaded (unnamed-module) class path,
+                            and each dependency ships its own MANIFEST.MF - shade generates the
+                            uber-jar manifest itself.
+                        -->
+                        <filters>
+                            <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                    <exclude>module-info.class</exclude>
+                                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    <exclude>META-INF/MANIFEST.MF</exclude>
+                                    <exclude>META-INF/DEPENDENCIES</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
+
                         <transformers>
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            <!-- Merge the Apache LICENSE/NOTICE files instead of clobbering one at random -->
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                            <!-- Concatenate HK2 service-locator descriptors so entries from every dependency survive -->
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <resource>META-INF/hk2-locator/default</resource>
+                            </transformer>
                         </transformers>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,11 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
-                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <!-- -processing: the metainf-services annotation processor deliberately
+                         does not claim @MetaInfServices (so other processors can also see it),
+                         and test frameworks use runtime annotations with no processor; the
+                         "No processor claimed ..." lint is noise here. -->
+                    <compilerArgument>-Xlint:all,-processing</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!-- Keep the useful doclint checks (broken references, malformed
+                         HTML, bad @param names) but do not warn about missing comments:
+                         the model layer is largely data-table enums and XJC-generated
+                         sources where per-element prose adds no value. -->
+                    <doclint>all,-missing</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**Merge order: 4 of 5 — merge after the CI, xls-fixes and build-tooling PRs.**

Stacked series; the diff collapses to just these commits once the earlier PRs merge.

## Summary
Clears the remaining reactor build warnings.

- **build(shade)** — merge Apache LICENSE/NOTICE and HK2 locator descriptors, filter `module-info`/duplicate MANIFEST/DEPENDENCIES, and exclude the redundant `jakarta.activation-api`.
- **build(assembly)** — `useProjectArtifact=false` for the pom-only dist module.
- **docs(api)** — add missing Javadoc and set `doclint` to `all,-missing`.
- **build** — resolve javac `-Xlint` warnings: `serialVersionUID`, `@SuppressWarnings("unchecked")` in a test mock, deprecated `Assert.assertThat` → `MatcherAssert.assertThat`, and `-Xlint:all,-processing`.

## Order
1. #166 → 2. xls fixes → 3. build tooling → 4. **this PR** → 5. docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)