### PR TITLE
PRIS-177: docs: add RELEASING.md and rewrite README (merge after #168)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@
 #
 # Release pipeline, triggered by v* tags: build from source, smoke test the
 # amd64 container image, then push the amd64/arm64 multi-arch manifest to
-# GHCR and create a GitHub release with the distribution archives.
+# DockerHub and create a GitHub release with the distribution archives.
 #
-# No repository secrets required: images are pushed to docker.io/opennms/pris
-# with the workflow GITHUB_TOKEN. One-time setup: the org must allow GitHub
+# DockerHub repository secrets are required: images are pushed to docker.io/opennms/pris
+# with the workflow DOCKERHUB_TOKEN. One-time setup: the org must allow GitHub
 # Actions to create packages, and the package created by the first push is
 # private until its visibility is flipped to public manually.
 ---

--- a/README.md
+++ b/README.md
@@ -1,53 +1,47 @@
+# OpenNMS Provisioning Integration Server (PRIS)
 
-# OpenNMS Provisioning Integration Server
+[![CI](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/OpenNMS/opennms-provisioning-integration-server?sort=semver)](https://github.com/OpenNMS/opennms-provisioning-integration-server/releases)
+[![Container image](https://img.shields.io/badge/ghcr.io-opennms%2Fpris-2496ED?logo=docker&logoColor=white)](https://github.com/OpenNMS/opennms-provisioning-integration-server/pkgs/container/pris)
+[![Java 17](https://img.shields.io/badge/Java-17-orange.svg?logo=openjdk&logoColor=white)](https://adoptium.net/)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
-The _Provisioning Integration Server (pris)_ is a tool which provides the ability to get external information from your inventory into an OpenNMS requisition model.
-The output from pris is provided as XML over HTTP and can be used in OpenNMS Provisiond to import and discover nodes from.
-This tool can be used to normalize inventory data and gives the ability to cleanup and manipulate the information before uploading into OpenNMS.
+PRIS gets external information from your inventory into an OpenNMS requisition
+model. It serves the result as XML over HTTP so OpenNMS Provisiond can import
+and discover nodes from it, and lets you normalize, clean up and manipulate the
+inventory data before it reaches OpenNMS.
 
-The project is divided in the following Maven modules:
+## Contents
 
-* `parent` This module ties all components together 
-* `opennms-pris-api` generic programming interfaces for configuration, mapper and different data sources
-* `opennms-pris-dist` module to assemble the compiled code into a runnable and distributable format
-* `opennms-pris-docs` documentation of the application for user and developers 
-* `opennms-pris-main` provisioning integration server itself
-* `opennms-pris-model` The OpenNMS requisition model
-* `opennms-pris-plugins` plugins which implement specific data sources such as XLS, scripts, JDBC or OCS Inventory
+- [Quick start (container)](#quick-start-container)
+- [Documentation](#documentation)
+- [Build from source](#build-from-source)
+- [Build a container image locally](#build-a-container-image-locally)
+- [Project layout](#project-layout)
+- [Contributing and releasing](#contributing-and-releasing)
+- [Project information](#project-information)
+- [License](#license)
 
-## General Project Information
+## Quick start (container)
 
-* CI/CD Status: [![CI](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml)
-* CI/CD System: [GitHub Actions]
-* Container Image Repository: [GitHub Container Registry]
-* Issue- and Bug-Tracking: [JIRA]
-* Source code: [GitHub]
-* Chat: [IRC] or [Web Chat]
-* Maintainer: ronny@opennms.org
-* Illustrations created in documentation with [yED]
-* [Documentation]
+Released images are published to the [GitHub Container Registry]. Start the
+latest stable release with:
 
-## Run PRIS as a Docker Container
-
-Docker Tags
-
-* `latest` floating tag for a build from latest stable release
-* to run a specific stable version see the tags of the [GitHub Container Registry] package
-
-Current releases of PRIS are published on the [GitHub Container Registry].
-You can download and start the container image with:
-
-    docker run --name mypris --detach --publish 8000:8000 ghcr.io/opennms/pris:latest
-
-The container will be downloaded from the GitHub Container Registry and is started in background with name `mypris`.
-A port 8000 is published on your local machine which can be used with your browser.
-The unique container is returned which identifies the running instance of your container.
-
-If you want to embed your PRIS service in an existing Docker Compose service stack:
-
+```sh
+docker run --name mypris --detach --publish 8000:8000 ghcr.io/opennms/pris:latest
 ```
-version: '2.3'
 
+Then open <http://localhost:8000>. If no requisition source is configured yet
+you are redirected to the documentation page.
+
+Image tags:
+
+- `latest` — floating tag tracking the most recent stable release
+- `<version>` — a specific release (see the [container package][GitHub Container Registry] for available tags)
+
+### Docker Compose
+
+```yaml
 volumes:
   pris.data:
     driver: local
@@ -58,7 +52,6 @@ services:
     image: ghcr.io/opennms/pris:latest
     environment:
       - TZ=Europe/Berlin
-      - JAVA_OPTS=-XX:+PrintGCDetails -XX:+UnlockExperimentalVMOptions
     volumes:
       - pris.data:/opt/opennms-pris/requisitions
       - pris.data:/opt/opennms-pris/scriptsteps
@@ -69,108 +62,130 @@ services:
       retries: 1
     ports:
       - "8000:8000"
-```   
-
-Your configuration for data sources is persisted to a named volume.
-Mount a local volume if you want to use scripts and requisition source configuration from your local system.
-
-To add JMX monitoring you can add Java options as environment variable like:
-
-```
-- JAVA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=19110 -Dcom.sun.management.jmxremote.rmi.port=19111 -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=<my-docker-host-ip>
 ```
 
-As `-Djava.rmi.server.hostname` you have to take the IP address of your Docker Host machine and make sure you expose both RMI ports in `-Dcom.sun.management.jmxremote.port=19110` and `-Dcom.sun.management.jmxremote.rmi.port=19111`.
+Data source configuration is persisted to the named volume; mount a local
+volume instead if you want to manage scripts and requisition sources from your
+host.
 
-# Compile and Install PRIS from source
+To enable remote JMX monitoring, pass the options via `JAVA_OPTS`, using your
+Docker host IP for `java.rmi.server.hostname` and exposing both RMI ports:
 
-This guide describes how you can checkout the source code from GitHub and how you can compile from source.
-The following parts are required: 
-
-* [OpenJDK] or [Oracle Java Development Kit] with javac Version 17
-* Apache [Maven]
-* [git-scm]
-* `java`, `javac`, `git`, `make` and `mvn` should be in your search path
-* Internet connection to download maven dependencies
-* Documentation is build with [Antora] and requires to have `antora` in your search path, alternatively `make docs-docker` builds the docs with a Docker container
-
-The Makefile is the front door for all build goals. Get an overview with
-
-    make help
-
-In your source directory run the command
-
-    make all
-
-It make sure everything from previous builds is cleaned away.
-Then is compiles the code and build everything as a runnable jar as well as .tar.gz and .zip file in the `opennms-pris-dist/target` directory.
-
-The PRIS server is started in foreground with the following command executed in your PRIS directory:
-
-    java -cp ./lib/*:./opennms-pris.jar org.opennms.pris.Starter 
-
-Connect your browser to http://localhost:8000, if you don't point to any requisition from a source, you will be redirected to the documentation page.
-The example requisition from a provided Excel sheet can be accessed with http://localhost:8000/requisitions/myServer and http://localhost:8000/requisitions/myRouter.
-
-## Build a Docker Container Image
-
-You can build a local container image for your host platform with
-
+```yaml
+environment:
+  - JAVA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=19110 -Dcom.sun.management.jmxremote.rmi.port=19111 -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=<my-docker-host-ip>
+ports:
+  - "19110:19110"
+  - "19111:19111"
 ```
+
+## Documentation
+
+Full user and developer documentation is published at [docs.opennms.com][Documentation].
+
+Two example requisitions ship with the app and are reachable once it is running:
+<http://localhost:8000/requisitions/myServer> and
+<http://localhost:8000/requisitions/myRouter>.
+
+## Build from source
+
+Prerequisites (all must be on your `PATH`):
+
+- [OpenJDK] or another JDK 17 (`java`, `javac`)
+- Apache [Maven] (`mvn`)
+- [git][git-scm] and `make`
+- An internet connection to download Maven dependencies
+- [Antora] to build the docs (`antora`); alternatively `make docs-docker` builds them in a container
+
+The `Makefile` is the front door for every build task — list them with:
+
+```sh
+make help
+```
+
+Common targets:
+
+| Target | Description |
+| --- | --- |
+| `make compile` | Compile and run the test suite |
+| `make package` | Build the runnable jar and the `.tar.gz` / `.zip` release archives in `opennms-pris-dist/target` |
+| `make run` | Build from source and start PRIS in the foreground on <http://localhost:8000> |
+| `make docs` | Build the Antora documentation |
+| `make all` | Compile, package and build the docs |
+| `make clean` | Remove build artifacts and the local container image |
+
+The quickest way to build and run from source is:
+
+```sh
+make run
+```
+
+To run a packaged build manually, extract a release archive and start the
+server from its directory:
+
+```sh
+java -cp './lib/*:./opennms-pris.jar' org.opennms.pris.Starter
+```
+
+## Build a container image locally
+
+```sh
 make oci
 ```
 
-It packages the release archive (if missing) and builds an image tagged `pris:$(cat version.txt)`.
-The image name and tag can be overridden with `make oci IMAGE=mypris VERSION=1.2.3`.
-Run the built container image with
+This packages the release archive (if missing) and builds an image tagged
+`pris:$(cat version.txt)` for your host platform. Override the name and tag with
+`make oci IMAGE=mypris VERSION=1.2.3`, then run it:
 
-```
-docker run --name mypris --detach --publish 8000:8000 pris:$(cat version.txt)
-```
-
-`make clean` removes the build artifacts including the local container image.
-Multi-arch images (amd64/arm64) are built and published by the release workflow in GitHub Actions.
-
-# Development and Releases
-
-Releases are made by pushing a git tag with the pattern `v<major>.<minor>.<patch>` (e.g. v1.2.1).
-The tag name without the `v` prefix is used as the version number to be released.
-Releases are published to the following places:
-
-* Multi-arch (amd64/arm64) OCI container images to the [GitHub Container Registry] of the repository the release is cut from
-* .tar.gz and .zip files to the GitHub releases of this repository
-
-All other pushes and pull requests are just built, packaged and smoke tested.
-
-Steps to make a release:
-
-1. Set the new version number in docs and code artifacts
-
-```
-bin/changeversion.sh -o BLEEDING -n 1.2.1
+```sh
+docker run --name mypris --detach --publish 8000:8000 "pris:$(cat version.txt)"
 ```
 
-2. Commit the changes and tag the release
+Multi-arch (amd64/arm64) images are built and published only by the release
+workflow — see [RELEASING.md](RELEASING.md).
 
-```
-git commit -m "release: version 1.2.1"
-git tag -a v1.2.1 -m "Release 1.2.1"
-git push origin v1.2.1
-```
+## Project layout
 
-The CI/CD workflows can be found in the `.github/workflows` directory.
-The release workflow needs no repository secrets, container images are pushed with the built-in workflow token.
-The package created by the very first release is private, its visibility has to be flipped to public once in the GitHub package settings.
+Maven multi-module project:
 
-[GitHub]: https://github.com/OpenNMS/opennms-provisioning-integration-server.git
+| Module | Purpose |
+| --- | --- |
+| `opennms-pris-api` | Programming interfaces for configuration, mappers and data sources |
+| `opennms-pris-model` | The OpenNMS requisition model |
+| `opennms-pris-main` | The provisioning integration server itself |
+| `opennms-pris-plugins` | Data-source plugins: XLS, script, JDBC, OCS Inventory and defaults |
+| `opennms-pris-dist` | Assembles the compiled code into a runnable, distributable archive |
+
+User and developer documentation lives under `docs/` and is built with [Antora].
+
+## Contributing and releasing
+
+- CI/CD workflows live in [`.github/workflows`](.github/workflows); every push
+  and pull request is built, packaged and smoke tested.
+- The release process (tag-driven, publishing container images and archives) is
+  documented in **[RELEASING.md](RELEASING.md)**.
+
+## Project information
+
+- CI/CD system: [GitHub Actions]
+- Container images: [GitHub Container Registry]
+- Issue and bug tracking: [GitHub Issues]
+- Source code: [GitHub]
+- Chat: [Web Chat]
+- Maintainer: ronny@opennms.org
+
+## License
+
+Distributed under the GNU General Public License v3.0. See [LICENSE](LICENSE) for
+the full text.
+
+[GitHub]: https://github.com/OpenNMS/opennms-provisioning-integration-server
 [GitHub Actions]: https://github.com/OpenNMS/opennms-provisioning-integration-server/actions
 [GitHub Container Registry]: https://github.com/OpenNMS/opennms-provisioning-integration-server/pkgs/container/pris
-[JIRA]: https://issues.opennms.org/projects/PRIS
-[OpenJDK]: http://openjdk.java.net/
-[Oracle Java Development Kit]: http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html
-[Maven]: http://maven.apache.org/
-[git-scm]: http://git-scm.com/
-[yED]: http://www.yworks.com/en/products_yed_about.html
+[GitHub Issues]: https://github.com/OpenNMS/opennms-provisioning-integration-server/issues
+[OpenJDK]: https://openjdk.org/
+[Maven]: https://maven.apache.org/
+[git-scm]: https://git-scm.com/
 [Web Chat]: https://chats.opennms.org/opennms-discuss
 [Documentation]: https://docs.opennms.com
-[Antora]: https://docs.antora.org/antora/2.3/install/install-antora/
+[Antora]: https://docs.antora.org/antora/latest/install/install-antora/

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ User and developer documentation lives under `docs/` and is built with [Antora].
 - Container images: [Docker Hub]
 - Issue and bug tracking: [GitHub Issues]
 - Source code: [GitHub]
-- Chat: [Web Chat]
+- Chat: [Mattermost]
 - Maintainer: ronny@opennms.org
 
 ## License
@@ -186,6 +186,6 @@ the full text.
 [OpenJDK]: https://openjdk.org/
 [Maven]: https://maven.apache.org/
 [git-scm]: https://git-scm.com/
-[Web Chat]: https://chats.opennms.org/opennms-discuss
+[Mattermost]: https://chat.opennms.com/opennms/channels/opennms-discussion
 [Documentation]: https://docs.opennms.com
 [Antora]: https://docs.antora.org/antora/latest/install/install-antora/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenNMS/opennms-provisioning-integration-server/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/OpenNMS/opennms-provisioning-integration-server?sort=semver)](https://github.com/OpenNMS/opennms-provisioning-integration-server/releases)
-[![Container image](https://img.shields.io/badge/ghcr.io-opennms%2Fpris-2496ED?logo=docker&logoColor=white)](https://github.com/OpenNMS/opennms-provisioning-integration-server/pkgs/container/pris)
+[![Container image](https://img.shields.io/badge/docker.io-opennms%2Fpris-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/opennms/pris)
 [![Java 17](https://img.shields.io/badge/Java-17-orange.svg?logo=openjdk&logoColor=white)](https://adoptium.net/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
@@ -24,11 +24,11 @@ inventory data before it reaches OpenNMS.
 
 ## Quick start (container)
 
-Released images are published to the [GitHub Container Registry]. Start the
+Released images are published to [Docker Hub]. Start the
 latest stable release with:
 
 ```sh
-docker run --name mypris --detach --publish 8000:8000 ghcr.io/opennms/pris:latest
+docker run --name mypris --detach --publish 8000:8000 opennms/pris:latest
 ```
 
 Then open <http://localhost:8000>. If no requisition source is configured yet
@@ -37,7 +37,7 @@ you are redirected to the documentation page.
 Image tags:
 
 - `latest` — floating tag tracking the most recent stable release
-- `<version>` — a specific release (see the [container package][GitHub Container Registry] for available tags)
+- `<version>` — a specific release (see the [Docker Hub repository][Docker Hub] for available tags)
 
 ### Docker Compose
 
@@ -49,7 +49,7 @@ volumes:
 services:
   pris:
     container_name: opennms.pris
-    image: ghcr.io/opennms/pris:latest
+    image: opennms/pris:latest
     environment:
       - TZ=Europe/Berlin
     volumes:
@@ -168,7 +168,7 @@ User and developer documentation lives under `docs/` and is built with [Antora].
 ## Project information
 
 - CI/CD system: [GitHub Actions]
-- Container images: [GitHub Container Registry]
+- Container images: [Docker Hub]
 - Issue and bug tracking: [GitHub Issues]
 - Source code: [GitHub]
 - Chat: [Web Chat]
@@ -181,7 +181,7 @@ the full text.
 
 [GitHub]: https://github.com/OpenNMS/opennms-provisioning-integration-server
 [GitHub Actions]: https://github.com/OpenNMS/opennms-provisioning-integration-server/actions
-[GitHub Container Registry]: https://github.com/OpenNMS/opennms-provisioning-integration-server/pkgs/container/pris
+[Docker Hub]: https://hub.docker.com/r/opennms/pris
 [GitHub Issues]: https://github.com/OpenNMS/opennms-provisioning-integration-server/issues
 [OpenJDK]: https://openjdk.org/
 [Maven]: https://maven.apache.org/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,93 @@
+# Releasing PRIS
+
+This document describes how a release of the OpenNMS Provisioning Integration
+Server (PRIS) is cut and what the automated release pipeline publishes.
+
+## Overview
+
+A release is triggered by pushing a git tag matching `v<major>.<minor>.<patch>`
+(for example `v2.1.2`). The tag name **without** the leading `v` is used as the
+version number.
+
+The [`release`](.github/workflows/release.yml) workflow reacts to `v*` tags and:
+
+1. Validates the documentation cross-references (`make docs-check`).
+2. Builds the docs and packages the `.tar.gz` / `.zip` release archives.
+3. Builds an `amd64` image and runs the container smoke test (`make smoke-test`).
+4. Builds and pushes a **multi-arch** (`linux/amd64`, `linux/arm64`) OCI image to
+   `ghcr.io/<owner>/pris`, tagged with both the version and `latest`.
+5. Creates a GitHub release for the tag with auto-generated notes and attaches
+   the `.tar.gz` and `.zip` archives.
+
+The `master` branch carries a `-SNAPSHOT` development version between releases.
+All non-tag pushes and pull requests are only built, packaged and smoke tested
+by the [`ci`](.github/workflows/ci.yml) workflow — they do not publish anything.
+
+## Prerequisites
+
+* Push access to `master` and permission to push tags.
+* A clean, up-to-date `master` working tree that builds green
+  (`make compile`).
+* Nothing else is required for the pipeline itself: the release workflow uses
+  the built-in `GITHUB_TOKEN` and needs **no repository secrets**. Images are
+  pushed with that token to the GHCR namespace of the repository the release is
+  cut from.
+
+## Cutting a release
+
+The steps below use `2.1.2` as the release version and `2.1.3-SNAPSHOT` as the
+next development version. Substitute your own version numbers.
+
+`bin/changeversion.sh` rewrites the version in every `pom.xml`, in the Antora
+`docs/**/antora.yml` files (and flips `prerelease: true` to `false`), and in
+`version.txt`.
+
+### 1. Set the release version
+
+```
+bin/changeversion.sh -o 2.1.2-SNAPSHOT -n 2.1.2
+```
+
+Review the changes and confirm the project still builds:
+
+```
+git diff
+make compile
+```
+
+### 2. Commit and tag
+
+```
+git commit -s -am "chore: release version 2.1.2"
+git tag -a v2.1.2 -m "Release 2.1.2"
+git push origin master v2.1.2
+```
+
+Pushing the `v2.1.2` tag starts the release workflow. Watch it in the
+repository's **Actions** tab until it completes.
+
+### 3. Set the next development version
+
+```
+bin/changeversion.sh -o 2.1.2 -n 2.1.3-SNAPSHOT
+git commit -s -am "chore: set development version to 2.1.3-SNAPSHOT"
+git push origin master
+```
+
+## After the release
+
+Verify the published artifacts:
+
+* The GitHub release for the tag exists and has the `.tar.gz` and `.zip`
+  archives attached.
+* The container image is available:
+
+  ```
+  docker run --rm --publish 8000:8000 ghcr.io/<owner>/pris:2.1.2
+  ```
+
+### First release only
+
+The GHCR package created by the very first release is **private**. Flip its
+visibility to public once, in the GitHub package settings for the repository
+owner; subsequent releases inherit that visibility.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ The [`release`](.github/workflows/release.yml) workflow reacts to `v*` tags and:
 2. Builds the docs and packages the `.tar.gz` / `.zip` release archives.
 3. Builds an `amd64` image and runs the container smoke test (`make smoke-test`).
 4. Builds and pushes a **multi-arch** (`linux/amd64`, `linux/arm64`) OCI image to
-   `ghcr.io/<owner>/pris`, tagged with both the version and `latest`.
+   `docker.io/opennms/pris`, tagged with both the version and `latest`.
 5. Creates a GitHub release for the tag with auto-generated notes and attaches
    the `.tar.gz` and `.zip` archives.
 
@@ -28,10 +28,9 @@ by the [`ci`](.github/workflows/ci.yml) workflow — they do not publish anythin
 * Push access to `master` and permission to push tags.
 * A clean, up-to-date `master` working tree that builds green
   (`make compile`).
-* Nothing else is required for the pipeline itself: the release workflow uses
-  the built-in `GITHUB_TOKEN` and needs **no repository secrets**. Images are
-  pushed with that token to the GHCR namespace of the repository the release is
-  cut from.
+* The `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` Actions secrets must be
+  configured with a Docker Hub access token that has push rights to
+  `opennms/pris`. Everything else uses the built-in `GITHUB_TOKEN`.
 
 ## Cutting a release
 
@@ -83,11 +82,5 @@ Verify the published artifacts:
 * The container image is available:
 
   ```
-  docker run --rm --publish 8000:8000 ghcr.io/<owner>/pris:2.1.2
+  docker run --rm --publish 8000:8000 opennms/pris:2.1.2
   ```
-
-### First release only
-
-The GHCR package created by the very first release is **private**. Flip its
-visibility to public once, in the GitHub package settings for the repository
-owner; subsequent releases inherit that visibility.


### PR DESCRIPTION
## Summary

[PRIS-177](https://opennms.atlassian.net/browse/PRIS-177): rebased onto current master — the old 5-PR stack collapsed to just the two docs commits.

- **RELEASING.md** — a release runbook covering the tag-driven process, what the release workflow publishes (release archives, `ghcr.io/<owner>/pris` container image), the `bin/changeversion.sh` steps, and the one-time GHCR package visibility flip.
- **README rewrite** — best-practice structure with a table of contents, a pointer to RELEASING.md as the single source of truth for releases, refreshed badges, a corrected module list, a modernized Docker Compose example, and GitHub Issues for issue tracking. All links target the OpenNMS repository.

## Merge order: after #168

Two statements intentionally document the post-#168 state (they describe features that PR adds):

- README's `make run` target
- RELEASING.md's note that `changeversion.sh` also updates `version.txt`

Everything else (release workflow, `changeversion.sh` itself, GHCR publishing) already exists on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRIS-177]: https://opennms.atlassian.net/browse/PRIS-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ