### PR TITLE
PRIS-173: Migrate PRIS to Jetty 12.1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           name: release-archives
           path: opennms-pris-dist/target/
       - name: Build container image
-        run: make oci
+        run: make docs-docker oci
       - name: Smoke test container image
         run: make smoke-test
       - name: Upload smoke test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           name: release-archives
           path: opennms-pris-dist/target/
       - name: Build container image
-        run: make docs-docker oci
+        run: make oci
       - name: Smoke test container image
         run: make smoke-test
       - name: Upload smoke test results

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,13 @@ docs-docker: deps-docs-docker ## Build the Antora docs with a docker container
 	@echo "Build Antora docs with docker ..."
 	docker run --rm -v $(WORKING_DIRECTORY):/antora $(DOCKER_ANTORA_IMAGE) --stacktrace generate $(SITE_FILE)
 
+# assembly.xml bundles ./public into the release archive as documentation/, so
+# build the docs first if they are missing. Uses docs-docker because this rule
+# only runs in oci flows, which require docker anyway; in CI the archive and
+# public/ are provided as prebuilt artifacts, so neither step runs there.
 $(RELEASE_ARCHIVE):
 	@echo "Release archive is missing, packaging it ..."
+	@if [ ! -d public ]; then $(MAKE) docs-docker; fi
 	$(MAKE) package
 
 oci-stage: $(RELEASE_ARCHIVE) ## Stage the release archive for the container build

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,13 @@ deps-docs-docker:
 deps-oci:
 	@command -v docker
 
-docs: deps-docs ## Build the Antora docs
+docs: public ## Build the Antora docs
+
+# The ./public directory is the Antora output that assembly.xml bundles into the
+# release archive as documentation/. Declared as a real target (not phony) so the
+# release archive can depend on it and be rebuilt when the docs change. deps-docs
+# is order-only so an existing public/ is reused instead of rebuilt every time.
+public: | deps-docs
 	@echo "Build Antora docs..."
 	antora --stacktrace $(SITE_FILE)
 
@@ -64,11 +70,11 @@ docs-docker: deps-docs-docker ## Build the Antora docs with a docker container
 	@echo "Build Antora docs with docker ..."
 	docker run --rm -v $(WORKING_DIRECTORY):/antora $(DOCKER_ANTORA_IMAGE) --stacktrace generate $(SITE_FILE)
 
-$(RELEASE_ARCHIVE):
-	@echo "Release archive is missing, packaging it ..."
+$(RELEASE_ARCHIVE): public
+	@echo "Release archive is missing or stale, packaging it ..."
 	$(MAKE) package
 
-oci-stage: $(RELEASE_ARCHIVE) ## Stage the release archive for the container build
+oci-stage: docs $(RELEASE_ARCHIVE) ## Stage the release archive (with docs) for the container build
 	cp $(RELEASE_ARCHIVE) docker/deploy/
 
 oci: deps-oci oci-stage ## Build a local container image for the host platform, tagged IMAGE:VERSION
@@ -97,4 +103,4 @@ clean-docs-cache: ## Clean Antora cache for git repositories and UI components
 
 clean-all: clean clean-docs-cache ## Clean everything including the Antora cache
 
-all: compile package docs ## Compile, package and build the docs
+all: compile docs package ## Compile, build the docs, then package (docs must precede package)

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,7 @@ deps-docs-docker:
 deps-oci:
 	@command -v docker
 
-docs: public ## Build the Antora docs
-
-# The ./public directory is the Antora output that assembly.xml bundles into the
-# release archive as documentation/. Declared as a real target (not phony) so the
-# release archive can depend on it and be rebuilt when the docs change. deps-docs
-# is order-only so an existing public/ is reused instead of rebuilt every time.
-public: | deps-docs
+docs: deps-docs ## Build the Antora docs
 	@echo "Build Antora docs..."
 	antora --stacktrace $(SITE_FILE)
 
@@ -70,11 +64,11 @@ docs-docker: deps-docs-docker ## Build the Antora docs with a docker container
 	@echo "Build Antora docs with docker ..."
 	docker run --rm -v $(WORKING_DIRECTORY):/antora $(DOCKER_ANTORA_IMAGE) --stacktrace generate $(SITE_FILE)
 
-$(RELEASE_ARCHIVE): public
-	@echo "Release archive is missing or stale, packaging it ..."
+$(RELEASE_ARCHIVE):
+	@echo "Release archive is missing, packaging it ..."
 	$(MAKE) package
 
-oci-stage: docs $(RELEASE_ARCHIVE) ## Stage the release archive (with docs) for the container build
+oci-stage: $(RELEASE_ARCHIVE) ## Stage the release archive for the container build
 	cp $(RELEASE_ARCHIVE) docker/deploy/
 
 oci: deps-oci oci-stage ## Build a local container image for the host platform, tagged IMAGE:VERSION
@@ -103,4 +97,4 @@ clean-docs-cache: ## Clean Antora cache for git repositories and UI components
 
 clean-all: clean clean-docs-cache ## Clean everything including the Antora cache
 
-all: compile docs package ## Compile, build the docs, then package (docs must precede package)
+all: compile package docs ## Compile, package and build the docs

--- a/opennms-pris-main/pom.xml
+++ b/opennms-pris-main/pom.xml
@@ -34,11 +34,6 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-rewrite</artifactId>
-        </dependency>
-
 
         <!-- Configuration -->
         <dependency>

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
@@ -29,10 +29,13 @@
 package org.opennms.pris.driver;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.opennms.pris.api.Configuration;
 
 /**
@@ -73,10 +76,15 @@ public class HttpServerDriver implements Driver {
         ContextHandler contextHandlerRequisitions = new ContextHandler(requisitionProviderHandler, "/requisitions");
 
         // provide the documentation
+        // Jetty 12 rejects a relative base resource as an "alias", so resolve
+        // "./documentation/" (relative to the working directory) to an absolute,
+        // normalized path before handing it to the ResourceHandler.
+        final Path documentationRoot = Paths.get("documentation").toAbsolutePath().normalize();
         ResourceHandler docuResourceHandler = new ResourceHandler();
         docuResourceHandler.setDirAllowed(true);
         docuResourceHandler.setWelcomeFiles("index.html");
-        docuResourceHandler.setBaseResourceAsString("./documentation/");
+        docuResourceHandler.setBaseResource(
+                ResourceFactory.of(docuResourceHandler).newResource(documentationRoot));
 
         // serving the docu at http://ip:port/
         ContextHandler rootContext = new ContextHandler(docuResourceHandler, "/");

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/HttpServerDriver.java
@@ -29,15 +29,11 @@
 package org.opennms.pris.driver;
 
 import java.net.InetSocketAddress;
-import org.eclipse.jetty.rewrite.handler.RedirectPatternRule;
-import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.opennms.pris.api.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A working mode providing a HTTP server publishing generated requisitions.
@@ -72,26 +68,22 @@ public class HttpServerDriver implements Driver {
                 this.config.getInt("port", 8000)));
         
         
-        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
-        
         // custom handling for requisitions
         RequisitionProviderHandler requisitionProviderHandler = new RequisitionProviderHandler();
-        ContextHandler contextHandlerRequisitions = new ContextHandler("/requisitions");
-        contextHandlerRequisitions.setHandler(requisitionProviderHandler);
-        contextHandlerCollection.addHandler(contextHandlerRequisitions);
-        
+        ContextHandler contextHandlerRequisitions = new ContextHandler(requisitionProviderHandler, "/requisitions");
+
         // provide the documentation
         ResourceHandler docuResourceHandler = new ResourceHandler();
-        docuResourceHandler.setDirectoriesListed(true);
-        docuResourceHandler.setWelcomeFiles(new String[]{"index.html"});
-        docuResourceHandler.setResourceBase("./documentation/");
+        docuResourceHandler.setDirAllowed(true);
+        docuResourceHandler.setWelcomeFiles("index.html");
+        docuResourceHandler.setBaseResourceAsString("./documentation/");
 
-        // redirecting http://ip:port/ to the docu
+        // serving the docu at http://ip:port/
+        ContextHandler rootContext = new ContextHandler(docuResourceHandler, "/");
 
-        ContextHandler rootContext = new ContextHandler("/");
-        rootContext.setHandler(docuResourceHandler);
-        contextHandlerCollection.addHandler(rootContext);
-        
+        ContextHandlerCollection contextHandlerCollection =
+                new ContextHandlerCollection(contextHandlerRequisitions, rootContext);
+
         server.setHandler(contextHandlerCollection);
 
         server.start();

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/RequisitionProviderHandler.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/RequisitionProviderHandler.java
@@ -28,58 +28,64 @@
 
 package org.opennms.pris.driver;
 
-import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
 import org.opennms.pris.RequisitionGenerator;
 import org.opennms.pris.model.Requisition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RequisitionProviderHandler extends AbstractHandler {
+public class RequisitionProviderHandler extends Handler.Abstract {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequisitionProviderHandler.class);
 
     @Override
-    public void handle(final String target,
-            final Request baseRequest,
-            final HttpServletRequest request,
-            final HttpServletResponse response) throws IOException,
-            ServletException {
+    public boolean handle(final Request request,
+            final Response response,
+            final Callback callback) throws Exception {
 
-        String[] pathParts = request.getPathInfo().substring(1).split("/");
-
-        baseRequest.setHandled(true);
+        // The path within the "/requisitions" context, e.g. "/example" for /requisitions/example
+        final String pathInContext = Request.getPathInContext(request);
+        final String[] pathParts = pathInContext.substring(1).split("/");
 
         // Get the instance for the request path
-        String instance = pathParts[0];
+        final String instance = pathParts.length > 0 ? pathParts[0] : "";
 
         if (instance == null || instance.isEmpty() || instance.contains("favicon.ico")) {
-            response.sendError(404, "No instance specified");
-        } else {
-            try {
-                LOGGER.debug("Handling request for instance: {}", instance);
-                // Create the requisition provider for the instance
-                final RequisitionGenerator requisitionProvider = new RequisitionGenerator(instance);
-
-                // Generate the requisition
-                final Requisition requisition = requisitionProvider.generate(instance);
-
-                // Create the marshaller for the requisition
-                final JAXBContext jaxbContext = JAXBContext.newInstance(Requisition.class);
-                final Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-                jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-                // Marshall the requisition and write it to the response stream
-                jaxbMarshaller.marshal(requisition, response.getOutputStream());
-            } catch (final Exception ex) {
-                response.sendError(500, ex.getMessage());
-                LOGGER.warn("Request failed", ex);
-            }
+            Response.writeError(request, response, callback, 404, "No instance specified");
+            return true;
         }
+
+        try {
+            LOGGER.debug("Handling request for instance: {}", instance);
+            // Create the requisition provider for the instance
+            final RequisitionGenerator requisitionProvider = new RequisitionGenerator(instance);
+
+            // Generate the requisition
+            final Requisition requisition = requisitionProvider.generate(instance);
+
+            // Create the marshaller for the requisition
+            final JAXBContext jaxbContext = JAXBContext.newInstance(Requisition.class);
+            final Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+            jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+            // Marshall the requisition and write it to the response
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            jaxbMarshaller.marshal(requisition, baos);
+
+            response.setStatus(200);
+            response.write(true, ByteBuffer.wrap(baos.toByteArray()), callback);
+        } catch (final Exception ex) {
+            LOGGER.warn("Request failed", ex);
+            Response.writeError(request, response, callback, 500, ex.getMessage());
+        }
+
+        return true;
     }
 }

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/RequisitionProviderHandler.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/RequisitionProviderHandler.java
@@ -28,10 +28,11 @@
 
 package org.opennms.pris.driver;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
+import java.io.OutputStream;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -52,12 +53,13 @@ public class RequisitionProviderHandler extends Handler.Abstract {
 
         // The path within the "/requisitions" context, e.g. "/example" for /requisitions/example
         final String pathInContext = Request.getPathInContext(request);
-        final String[] pathParts = pathInContext.substring(1).split("/");
 
-        // Get the instance for the request path
-        final String instance = pathParts.length > 0 ? pathParts[0] : "";
+        // Get the instance for the request path (first path segment)
+        final String instance = pathInContext.isEmpty()
+                ? ""
+                : pathInContext.substring(1).split("/", 2)[0];
 
-        if (instance == null || instance.isEmpty() || instance.contains("favicon.ico")) {
+        if (instance.isEmpty() || instance.contains("favicon.ico")) {
             Response.writeError(request, response, callback, 404, "No instance specified");
             return true;
         }
@@ -75,12 +77,14 @@ public class RequisitionProviderHandler extends Handler.Abstract {
             final Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
             jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-            // Marshall the requisition and write it to the response
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            jaxbMarshaller.marshal(requisition, baos);
-
             response.setStatus(200);
-            response.write(true, ByteBuffer.wrap(baos.toByteArray()), callback);
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/xml");
+
+            // Marshall the requisition and stream it to the response
+            try (OutputStream out = Content.Sink.asOutputStream(response)) {
+                jaxbMarshaller.marshal(requisition, out);
+            }
+            callback.succeeded();
         } catch (final Exception ex) {
             LOGGER.warn("Request failed", ex);
             Response.writeError(request, response, callback, 500, ex.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
                 <version>${jettyServerVersion}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-rewrite</artifactId>
-                <version>${jettyServerVersion}</version>
-            </dependency>
-
             <!-- SPI -->
             <dependency>
                 <groupId>org.kohsuke.metainf-services</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jaxbApiVersion>2.3.1</jaxbApiVersion>
         <jaxbCoreVersion>2.3.0.1</jaxbCoreVersion>
         <jaxbImplVersion>2.3.9</jaxbImplVersion>
-        <jettyServerVersion>10.0.20</jettyServerVersion>
+        <jettyServerVersion>12.1.11</jettyServerVersion>
         <junitVersion>4.13.2</junitVersion>
         <mavenAssemblyPluginVersion>3.7.1</mavenAssemblyPluginVersion>
         <mavenCompilerPluginVersion>3.13.0</mavenCompilerPluginVersion>


### PR DESCRIPTION
Migrate PRIS to the latest Jetty to address CVE-2025-11143. Rewrite RequisitionProviderHandler to use Handler.Abstract, and HttpServerDriver to use the new ContextHandler/ResourceHandler API.

All tests + smoke test passed.

Resolves: [JIRA PRIS-173](https://opennms.atlassian.net/browse/PRIS-173)