### PR TITLE
PRIS-175: Fix silent file driver: instance discovery scanned the wrong directory

### DIFF
--- a/docs/modules/driver/examples/file.global.properties
+++ b/docs/modules/driver/examples/file.global.properties
@@ -1,8 +1,8 @@
 ### File: global.properties
-# Generate an requistion and create an requisition file to target
-# Create a file for all requisitions matching * (Java regular expression)
+# Generate a requisition and create a requisition file to target
+# Create a file for all requisitions matching * (glob pattern)
 
 loglevel = INFO
 driver = file
 target = /my/output/folder
-requistions = *
+requisitions = *

--- a/docs/modules/driver/pages/file.adoc
+++ b/docs/modules/driver/pages/file.adoc
@@ -9,7 +9,7 @@ To use the _file driver_ you have to set the parameters in the `global.propertie
 | Parameter      | Required | Description
 | `driver`       | *        | set to `file` to generate OpenNMS requisitions as XML file
 | `target`       | *        | `path/to/output/folder` for XML files to generate
-| `requisitions` |          | parameter as Java regular expression filter for the requisition name
+| `requisitions` |          | glob pattern filter for the requisition name, e.g. `my*`; defaults to `*`
 |===
 
 .Example configuration for a file based requisition

--- a/docs/modules/sources/examples/file/global.properties
+++ b/docs/modules/sources/examples/file/global.properties
@@ -1,7 +1,7 @@
 ### File: global.properties
-# Generate an requistion and create an requisition file to target
-# Create a file for all requisitions matching * (Java regular expression)
+# Generate a requisition and create a requisition file to target
+# Create a file for all requisitions matching * (glob pattern)
 
 driver = file
 target = /my/output/folder
-requistions = *
+requisitions = *

--- a/opennms-pris-main/src/main/java/org/opennms/pris/ConfigManager.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/ConfigManager.java
@@ -28,7 +28,6 @@
 
 package org.opennms.pris;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -36,11 +35,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import org.opennms.pris.api.Configuration;
 import org.opennms.pris.api.InstanceConfiguration;
 import org.opennms.pris.config.GlobalApacheConfiguration;
 import org.opennms.pris.config.InstanceApacheConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The configuration manager.
@@ -51,11 +53,16 @@ import org.opennms.pris.config.InstanceApacheConfiguration;
  *
  * The global configuration is loaded from the {@literal config.properties} in the base path. These properties can be overwritten by the system properties.
  *
- * The instance configurations are loaded from sub-folders relative to the configuration base path where the instance name in the folder name.
+ * The instance configurations are loaded from sub-folders of the {@literal requisitions} folder relative to the configuration base path where the instance name is the folder name.
  *
  * @author Dustin Frisch &lt;fooker@lab.sh&gt;
  */
 public class ConfigManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigManager.class);
+
+    // The folder relative to the config base path holding the instance configurations
+    private static final String REQUISITIONS_FOLDER = "requisitions";
 
     // The base path of the config
     private final Path base;
@@ -79,7 +86,7 @@ public class ConfigManager {
     /**
      * Returns all known instance names.
      *
-     * All sub-folders of the base directory having a {@literal requisition.properties} file are interpreted as instance configurations.
+     * All sub-folders of the {@literal requisitions} folder having a {@literal requisition.properties} file are interpreted as instance configurations.
      *
      * @return a collection of instance names
      */
@@ -90,7 +97,7 @@ public class ConfigManager {
     /**
      * Returns all known instance names matching the provided glob.
      *
-     * All sub-folders of the base directory matching the passed glob and having a {@literal  requisition.properties} file are interpreted as instance configurations.
+     * All sub-folders of the {@literal requisitions} folder matching the passed glob and having a {@literal requisition.properties} file are interpreted as instance configurations.
      *
      * The provided glob pattern is used to limit the returned instances to those matching the glob. To return all instances, {@code "*"} can be passed.
      *
@@ -99,7 +106,15 @@ public class ConfigManager {
      * @return a collection of instance names
      */
     public Collection<String> getInstances(final String glob) {
-        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(this.base, glob)) {
+        final Path requisitions = this.getRequisitionsPath();
+
+        // A missing requisitions folder is an operator state, not an error - there are just no instances
+        if (!Files.isDirectory(requisitions)) {
+            LOGGER.warn("Requisitions folder does not exist: {}", requisitions.toAbsolutePath());
+            return Collections.emptyList();
+        }
+
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(requisitions, glob)) {
 
             // The list of found instances
             final Collection<String> instances = new ArrayList<>();
@@ -112,9 +127,9 @@ public class ConfigManager {
                     continue;
                 }
 
-                // Get the name of the folder relative to the base folder and add it to
+                // Get the name of the folder relative to the requisitions folder and add it to
                 // the list of known instances
-                instances.add(this.base.relativize(path).toString());
+                instances.add(requisitions.relativize(path).toString());
             }
 
             return instances;
@@ -134,8 +149,20 @@ public class ConfigManager {
      * @return the instance configuration
      */
     public InstanceConfiguration getInstanceConfig(final String instance) {
-        return new InstanceApacheConfiguration(this.base.resolve("requisitions" + File.separator + instance),
+        return new InstanceApacheConfiguration(this.getRequisitionsPath().resolve(instance),
                                                instance);
+    }
+
+    /**
+     * Returns the folder holding the instance configurations.
+     *
+     * Instance discovery ({@link #getInstances}) and instance loading ({@link #getInstanceConfig}) MUST resolve
+     * against this same path.
+     *
+     * @return the requisitions folder
+     */
+    private Path getRequisitionsPath() {
+        return this.base.resolve(REQUISITIONS_FOLDER);
     }
     
     public InstanceConfiguration getInstanceConfigWithGlobals(final String instance) {

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
@@ -72,6 +72,10 @@ public class FileDriver implements Driver {
 
     @Override
     public void run() throws Exception {
+        // Resolve the target directory first so a missing 'target' is diagnosed
+        // even when no instances match (getString throws on the unset key)
+        final Path targetBase = Paths.get(this.config.getString("target"));
+
         // Get the instance matching glob and find all matching instances
         final String instanceGlob = this.config.getString("requisitions", "*");
         final Collection<String> instances = Starter.getConfigManager().getInstances(instanceGlob);
@@ -82,8 +86,7 @@ public class FileDriver implements Driver {
         }
         LOGGER.info("Generating requisitions for {} instance(s) matching '{}'", instances.size(), instanceGlob);
 
-        // Get the target directory and ensure it exist
-        final Path targetBase = Paths.get(this.config.getString("target"));
+        // Ensure the target directory exists
         Files.createDirectories(targetBase);
 
         // Loop over all instances

--- a/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/driver/FileDriver.java
@@ -76,6 +76,12 @@ public class FileDriver implements Driver {
         final String instanceGlob = this.config.getString("requisitions", "*");
         final Collection<String> instances = Starter.getConfigManager().getInstances(instanceGlob);
 
+        if (instances.isEmpty()) {
+            LOGGER.warn("No requisition instances found matching '{}' - nothing to generate", instanceGlob);
+            return;
+        }
+        LOGGER.info("Generating requisitions for {} instance(s) matching '{}'", instances.size(), instanceGlob);
+
         // Get the target directory and ensure it exist
         final Path targetBase = Paths.get(this.config.getString("target"));
         Files.createDirectories(targetBase);

--- a/opennms-pris-main/src/test/java/org/opennms/pris/ConfigManagerTest.java
+++ b/opennms-pris-main/src/test/java/org/opennms/pris/ConfigManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+
+package org.opennms.pris;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that instance discovery ({@code getInstances}) and instance loading ({@code getInstanceConfig})
+ * agree on the {@literal requisitions} folder as the location of instance configurations.
+ */
+public class ConfigManagerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Path base;
+
+    private String oldConfigProperty;
+
+    @Before
+    public void setUp() throws IOException {
+        this.base = this.tempFolder.getRoot().toPath();
+
+        // ConfigManager requires a global.properties in the config base folder
+        Files.createFile(this.base.resolve("global.properties"));
+
+        this.oldConfigProperty = System.setProperty("pris.config", this.base.toString());
+    }
+
+    @After
+    public void tearDown() {
+        if (this.oldConfigProperty == null) {
+            System.clearProperty("pris.config");
+        } else {
+            System.setProperty("pris.config", this.oldConfigProperty);
+        }
+    }
+
+    private void createInstance(final String name) throws IOException {
+        final Path instanceFolder = this.base.resolve("requisitions").resolve(name);
+        Files.createDirectories(instanceFolder);
+        Files.write(instanceFolder.resolve("requisition.properties"),
+                    Arrays.asList("source = file", "mapper = echo"));
+    }
+
+    @Test
+    public void discoversInstancesInRequisitionsFolder() throws IOException {
+        this.createInstance("alpha");
+        this.createInstance("beta");
+
+        // A folder without a requisition.properties is not an instance
+        Files.createDirectories(this.base.resolve("requisitions").resolve("no-instance"));
+
+        // A plain file in the requisitions folder is not an instance
+        Files.createFile(this.base.resolve("requisitions").resolve("inventory.xls"));
+
+        final Collection<String> instances = new ConfigManager().getInstances();
+
+        assertEquals(new HashSet<>(Arrays.asList("alpha", "beta")), new HashSet<>(instances));
+    }
+
+    @Test
+    public void filtersInstancesByGlob() throws IOException {
+        this.createInstance("myRouter");
+        this.createInstance("myServer");
+        this.createInstance("other");
+
+        final Collection<String> instances = new ConfigManager().getInstances("my*");
+
+        assertEquals(new HashSet<>(Arrays.asList("myRouter", "myServer")), new HashSet<>(instances));
+    }
+
+    @Test
+    public void missingRequisitionsFolderYieldsNoInstances() {
+        final Collection<String> instances = new ConfigManager().getInstances();
+
+        assertTrue("expected no instances without a requisitions folder", instances.isEmpty());
+    }
+
+    @Test
+    public void discoveredInstancesAreLoadable() throws IOException {
+        this.createInstance("alpha");
+
+        final ConfigManager configManager = new ConfigManager();
+
+        // Every discovered instance must be loadable by getInstanceConfig - this pins
+        // discovery and loading to the same folder
+        for (final String instance : configManager.getInstances()) {
+            assertEquals("file", configManager.getInstanceConfig(instance).getString("source"));
+        }
+    }
+}

--- a/opennms-pris-main/src/test/java/org/opennms/pris/ConfigManagerTest.java
+++ b/opennms-pris-main/src/test/java/org/opennms/pris/ConfigManagerTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2026 The OpenNMS Group, Inc.
  *
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: GPL-3.0-or-later
  *
  * Created by Ronny Trommer <ronny@opennms.com>
  */


### PR DESCRIPTION
## Summary

[PRIS-175](https://opennms.atlassian.net/browse/PRIS-175): commit `a4139f95` (2014) moved instance configurations into the `requisitions/` folder but only updated `ConfigManager.getInstanceConfig()` — `getInstances()` kept scanning the config base folder one level too high. With the documented layout it found nothing, so `driver = file` exited successfully having written **zero files**, silently, in every release since 2014.

## Changes

- **`ConfigManager`**: both `getInstances()` and `getInstanceConfig()` now resolve against a single `getRequisitionsPath()`, so discovery and loading cannot drift apart again. A missing `requisitions/` folder yields an empty instance list with a WARN instead of a `RuntimeException` — an operator state, not a server error (this also matters for the planned unknown-instance validation in [PRIS-174](https://opennms.atlassian.net/browse/PRIS-174)).
- **`FileDriver`**: reports how many instances it generates (INFO) and warns instead of staying silent when nothing matches — the silence is what let this bug hide for 12 years.
- **Tests**: first unit tests for `ConfigManager` (discovery in `requisitions/`, glob filtering, missing-folder behavior, and a pin that every discovered instance is loadable via `getInstanceConfig`).
- **Docs**: both file-driver examples spelled the key `requistions` (silently ignored; the driver reads `requisitions`) and called the pattern a Java regular expression — it is a `Files.newDirectoryStream` glob.

## Verification

- `ConfigManagerTest`: 4/4 pass
- File driver against the documented example layout (`requisitions/myFileRequisition/`): **0 files before, `myFileRequisition.xml` generated after**, with `INFO Generating requisitions for 1 instance(s) matching '*'`
- Empty config dir: `WARN Requisitions folder does not exist: …` + `WARN No requisition instances found matching '*' - nothing to generate`
- Container smoke test (docs root, `/requisitions/myRouter`, `/requisitions/myServer`): passed — HTTP driver path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRIS-175]: https://opennms.atlassian.net/browse/PRIS-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRIS-174]: https://opennms.atlassian.net/browse/PRIS-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ