### PR TITLE
Fix PR labeler: migrate config to actions/labeler v6 schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 docs:
-- 'docs/*'
-- 'docs/**/*'
-- '**/*.adoc'
+- changed-files:
+  - any-glob-to-any-file:
+    - 'docs/**'
+    - '**/*.adoc'


### PR DESCRIPTION
## Summary

Dependabot bumped `actions/labeler` to **6.2.0** (#178), but `.github/labeler.yml` was still in the v4 format (label → flat list of globs). The config schema changed in v5 — each label needs an array of match objects — so the `label` job now fails at config parse time on **every** pull request (first seen on #180):

```
Error: found unexpected type for label 'docs' (should be array of config options)
```

## Change

Rewrite the config to the v6 schema; `docs/*` + `docs/**/*` collapse into `docs/**`:

```yaml
docs:
- changed-files:
  - any-glob-to-any-file:
    - 'docs/**'
    - '**/*.adoc'
```

Note: the `label` job on *this* PR still runs the old config — `pull_request_target` workflows read the config from the base branch, so the fix takes effect for PRs opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)