### PR TITLE
Centralize module-local version properties in the root pom

### DIFF
--- a/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-ocs/pom.xml
@@ -15,9 +15,6 @@
 
     <name>OpenNMS :: Provisioning Integration Server :: Plugins :: OCS</name>
 
-    <properties>
-        <ocsInventoryClientVersion>1.0.1</ocsInventoryClientVersion>
-    </properties>
 
     <dependencies>
         <!-- OCS-Inventory -->

--- a/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
+++ b/opennms-pris-plugins/opennms-pris-plugins-xls/pom.xml
@@ -14,9 +14,6 @@
 
    <name>OpenNMS :: Provisioning Integration Server :: Plugins :: XLS</name>
 
-   <properties>
-      <apachePoiVersion>5.5.1</apachePoiVersion>
-   </properties>
 
    <dependencies>
       <!-- XLS -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
         <!-- Version settings -->
         <apacheDerbyVersion>10.14.2.0</apacheDerbyVersion>
+        <apachePoiVersion>5.5.1</apachePoiVersion>
         <beanshellVersion>2.0b5</beanshellVersion>
         <chQosLogbackVersion>1.5.6</chQosLogbackVersion>
         <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
@@ -54,6 +55,7 @@
         <mavenShadePluginVersion>3.6.2</mavenShadePluginVersion>
         <metainfServicesVersion>1.11</metainfServicesVersion>
         <mysqlConnectorVersion>8.0.33</mysqlConnectorVersion>
+        <ocsInventoryClientVersion>1.0.1</ocsInventoryClientVersion>
         <opennmsVersion>33.0.4</opennmsVersion>
         <opennmsApiVersion>2.0.0</opennmsApiVersion>
         <postgresqlDriverVersion>42.7.13</postgresqlDriverVersion>


### PR DESCRIPTION
## Summary

`apachePoiVersion` (xls plugin) and `ocsInventoryClientVersion` (ocs plugin) were the only two version properties defined in module poms rather than the root pom's "Version settings" block.

The module-local `apachePoiVersion` is what made Dependabot double-track the POI updates: one PR for the shared property from the root scan (#159, merged at 5.5.1) and one for a single artifact within the module directory (#174, now stale at 5.4.0 and conflicting). Centralizing the property removes the trigger for duplicate update PRs and matches the convention used by every other dependency version in this repo.

**No version changes** — 5.5.1 and 1.0.1 move as-is; both modules inherit them from the parent.

## Verification

- `mvn help:evaluate` in each module context resolves `apachePoiVersion=5.5.1` and `ocsInventoryClientVersion=1.0.1` from the parent
- `mvn package` of both plugin modules succeeds; shaded ocs jar bundles `ocs.inventory.client` 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)