### PR TITLE
PRIS-181: Migrate from Commons Configuration 1.10 to Commons Configuration 2.x

### DIFF
--- a/opennms-pris-main/pom.xml
+++ b/opennms-pris-main/pom.xml
@@ -37,8 +37,8 @@
 
         <!-- Configuration -->
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
     </dependencies>
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/config/AbstractApacheConfiguration.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/config/AbstractApacheConfiguration.java
@@ -37,18 +37,14 @@ import java.util.List;
 import org.opennms.pris.api.Configuration;
 
 public abstract class AbstractApacheConfiguration implements Configuration {
-    
-    private final org.apache.commons.configuration.Configuration config;
 
-    public org.apache.commons.configuration.Configuration getConfiguration() {
-        return config;
-    }
-    
-    protected AbstractApacheConfiguration(final org.apache.commons.configuration.Configuration config) {
+    private final org.apache.commons.configuration2.Configuration config;
+
+    protected AbstractApacheConfiguration(final org.apache.commons.configuration2.Configuration config) {
         this.config = config;
     }
 
-    protected org.apache.commons.configuration.Configuration getConfig() {
+    protected org.apache.commons.configuration2.Configuration getConfig() {
         return config;
     }
 

--- a/opennms-pris-main/src/main/java/org/opennms/pris/config/GlobalApacheConfiguration.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/config/GlobalApacheConfiguration.java
@@ -28,33 +28,44 @@
 
 package org.opennms.pris.config;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.CompositeConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.SystemConfiguration;
+import org.apache.commons.configuration2.convert.LegacyListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.opennms.pris.api.Configuration;
 
 public class GlobalApacheConfiguration extends AbstractApacheConfiguration implements Configuration {
 
-    private static org.apache.commons.configuration.Configuration createConfig(final Path base) {
+    private static org.apache.commons.configuration2.Configuration createConfig(final Path base) {
         // Load system and file properties
-        final org.apache.commons.configuration.SystemConfiguration systemConfig;
-        final org.apache.commons.configuration.PropertiesConfiguration propertiesConfig;
-        try {
-            systemConfig = new org.apache.commons.configuration.SystemConfiguration();
-            
-            propertiesConfig = new org.apache.commons.configuration.PropertiesConfiguration(base.resolve("global.properties").toFile());
-            
-        } catch (final ConfigurationException ex) {
-            throw new RuntimeException(ex);
-        }
-        
-        // Build composition of system properties and config file
-        return new CompositeConfiguration() {{
-            addConfiguration(systemConfig);
-            addConfiguration(propertiesConfig);
+        final SystemConfiguration systemConfig = new SystemConfiguration();
+        systemConfig.setListDelimiterHandler(new LegacyListDelimiterHandler(','));
 
-            setThrowExceptionOnMissing(true);
-        }};
+        // The global.properties stays optional like with Commons
+        // Configuration 1.x, which created an empty configuration when the
+        // file was absent
+        final Path path = base.resolve("global.properties");
+        final PropertiesConfiguration propertiesConfig = new PropertiesConfiguration();
+        propertiesConfig.setListDelimiterHandler(new LegacyListDelimiterHandler(','));
+        if (Files.exists(path)) {
+            try {
+                new FileHandler(propertiesConfig).load(path.toFile());
+            } catch (final ConfigurationException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        // Build composition of system properties and config file
+        final CompositeConfiguration config = new CompositeConfiguration();
+        config.addConfiguration(systemConfig);
+        config.addConfiguration(propertiesConfig);
+        config.setListDelimiterHandler(new LegacyListDelimiterHandler(','));
+        config.setThrowExceptionOnMissing(true);
+        return config;
     }
 
     private final Path basePath;

--- a/opennms-pris-main/src/main/java/org/opennms/pris/config/InstanceApacheConfiguration.java
+++ b/opennms-pris-main/src/main/java/org/opennms/pris/config/InstanceApacheConfiguration.java
@@ -30,13 +30,15 @@ package org.opennms.pris.config;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.convert.LegacyListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.opennms.pris.api.InstanceConfiguration;
 
 public class InstanceApacheConfiguration extends AbstractApacheConfiguration implements InstanceConfiguration {
 
-    private static org.apache.commons.configuration.Configuration createConfig(final Path basePath) {
+    private static org.apache.commons.configuration2.Configuration createConfig(final Path basePath) {
         final Path path = basePath.resolve("requisition.properties");
 
         // Raise wrapped file not found exception if the config file does not exist
@@ -44,14 +46,15 @@ public class InstanceApacheConfiguration extends AbstractApacheConfiguration imp
             throw new RuntimeException("Config file not found: " + path);
         }
 
-        // Load system and file properties
+        // Load via FileHandler directly (no builder, which would require
+        // commons-beanutils). No reloading strategy needed: the ConfigManager
+        // builds a fresh configuration for every request anyway.
         try {
-            return new org.apache.commons.configuration.PropertiesConfiguration(path.toFile()) {
-                {
-                    setThrowExceptionOnMissing(true);
-                    setReloadingStrategy(new FileChangedReloadingStrategy());
-                }
-            };
+            final PropertiesConfiguration config = new PropertiesConfiguration();
+            config.setListDelimiterHandler(new LegacyListDelimiterHandler(','));
+            config.setThrowExceptionOnMissing(true);
+            new FileHandler(config).load(path.toFile());
+            return config;
 
         } catch (final ConfigurationException ex) {
             throw new RuntimeException(ex);
@@ -71,7 +74,7 @@ public class InstanceApacheConfiguration extends AbstractApacheConfiguration imp
 
     private InstanceApacheConfiguration(final Path basePath,
                                         final String instance,
-                                        final org.apache.commons.configuration.Configuration config) {
+                                        final org.apache.commons.configuration2.Configuration config) {
         super(config);
 
         this.basePath = basePath;

--- a/opennms-pris-main/src/test/java/org/opennms/pris/config/ConfigManagerGlobalsMergeTest.java
+++ b/opennms-pris-main/src/test/java/org/opennms/pris/config/ConfigManagerGlobalsMergeTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.pris.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.pris.ConfigManager;
+import org.opennms.pris.api.InstanceConfiguration;
+
+/**
+ * Characterization tests for the merge performed by
+ * {@code ConfigManager.getInstanceConfigWithGlobals}, where the global
+ * {@code CompositeConfiguration} (system properties layered over
+ * global.properties) is copied key by key into the instance configuration.
+ *
+ * The merge copies values through {@code getString}/{@code addProperty}, so it
+ * is the one place where the list delimiter handling of both configurations
+ * meets. The 2.x migration (PRIS-181) must keep every one of these green,
+ * including the lossy cases pinned down below.
+ */
+public class ConfigManagerGlobalsMergeTest {
+
+    private static final String SYS_ONLY_KEY = "pris.test.sysonly";
+
+    private static final String SYS_OVER_INSTANCE_KEY = "pris.test.instancewins";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path base;
+
+    private Path instanceDir;
+
+    @Before
+    public void setUp() throws IOException {
+        base = folder.getRoot().toPath();
+        Files.write(base.resolve("global.properties"), String.join("\n",
+                "gtags = alpha, beta",
+                "glabel = a\\, b",
+                "gfile = steps.groovy",
+                "gscripts = one.groovy, two.groovy",
+                SYS_ONLY_KEY + " = from-file")
+                .getBytes(StandardCharsets.ISO_8859_1));
+
+        instanceDir = Files.createDirectories(base.resolve("requisitions").resolve("myreq"));
+        Files.write(instanceDir.resolve("requisition.properties"), String.join("\n",
+                "source = xls",
+                SYS_OVER_INSTANCE_KEY + " = from-instance")
+                .getBytes(StandardCharsets.ISO_8859_1));
+
+        System.setProperty(SYS_ONLY_KEY, "from-system");
+        System.setProperty(SYS_OVER_INSTANCE_KEY, "from-system");
+        System.setProperty("pris.config", base.toString());
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(SYS_ONLY_KEY);
+        System.clearProperty(SYS_OVER_INSTANCE_KEY);
+        System.clearProperty("pris.config");
+    }
+
+    private InstanceConfiguration merged() {
+        return new ConfigManager().getInstanceConfigWithGlobals("myreq");
+    }
+
+    @Test
+    public void systemPropertyReachesTheInstanceConfigThroughTheMerge() {
+        // The system layer of the CompositeConfiguration is visible on the
+        // merged instance config, not just on the global config itself
+        assertThat(merged().getString(SYS_ONLY_KEY), is("from-system"));
+    }
+
+    @Test
+    public void systemPropertyWinsOverGlobalFileThroughTheMerge() {
+        // SYS_ONLY_KEY is set in both global.properties and the system
+        // properties - the composite adds the system config first, so the
+        // file value never reaches the instance config
+        assertThat(new GlobalApacheConfiguration(base).getString(SYS_ONLY_KEY), is("from-system"));
+        assertThat(merged().getString(SYS_ONLY_KEY), is("from-system"));
+    }
+
+    @Test
+    public void instanceValueWinsOverSystemProperty() {
+        // Completes the precedence chain instance > system > global.properties:
+        // the merge skips keys the instance already defines
+        assertThat(merged().getString(SYS_OVER_INSTANCE_KEY), is("from-instance"));
+    }
+
+    @Test
+    public void multiValueGlobalKeySurvivesTheMerge() {
+        // A plain comma list round-trips through the join-on-read,
+        // split-on-write of the merge
+        assertThat(merged().getStringArray("gtags"), arrayContaining("alpha", "beta"));
+        assertThat(merged().getString("gtags"), is("alpha,beta"));
+    }
+
+    @Test
+    public void escapedCommaInGlobalValueIsSplitByTheMerge() {
+        // The global config reads the escaped comma as a single value ...
+        assertThat(new GlobalApacheConfiguration(base).getStringArray("glabel"),
+                   arrayContaining("a, b"));
+
+        // ... but the merge copies it as the joined string "a, b" and the
+        // instance config splits it again on the delimiter, dropping the
+        // escape. Pre-existing lossy behavior of the key-by-key copy, kept
+        // as-is by the 2.x migration.
+        assertThat(merged().getStringArray("glabel"), arrayContaining("a", "b"));
+        assertThat(merged().getString("glabel"), is("a,b"));
+    }
+
+    @Test
+    public void globalPathValueResolvesAgainstTheInstanceDirectory() {
+        // Path-valued globals are resolved by the instance config, so they
+        // resolve against the instance folder - not against the config base
+        // folder the value was written in
+        assertThat(merged().getPath("gfile"), is(instanceDir.resolve("steps.groovy")));
+        assertThat(merged().getPaths("gscripts"), contains(instanceDir.resolve("one.groovy"),
+                                                           instanceDir.resolve("two.groovy")));
+    }
+
+    @Test
+    public void presetRequisitionKeyGainsTheInstanceNameAsSecondValue() throws IOException {
+        // The merge adds the instance name as the "requisition" property
+        // unconditionally, so a requisition.properties that already sets the
+        // key ends up holding two values instead of being overwritten
+        final Path preset = Files.createDirectories(base.resolve("requisitions").resolve("preset"));
+        Files.write(preset.resolve("requisition.properties"),
+                    "requisition = other".getBytes(StandardCharsets.ISO_8859_1));
+
+        final InstanceConfiguration config = new ConfigManager().getInstanceConfigWithGlobals("preset");
+        assertThat(config.getStringArray("requisition"), arrayContaining("other", "preset"));
+        assertThat(config.getString("requisition"), is("other,preset"));
+    }
+}

--- a/opennms-pris-main/src/test/java/org/opennms/pris/config/GlobalApacheConfigurationTest.java
+++ b/opennms-pris-main/src/test/java/org/opennms/pris/config/GlobalApacheConfigurationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.pris.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.pris.ConfigManager;
+import org.opennms.pris.api.InstanceConfiguration;
+
+/**
+ * Characterization tests for the global configuration and its merge into
+ * instance configurations. The 2.x migration (PRIS-181) must keep every one
+ * of these green.
+ */
+public class GlobalApacheConfigurationTest {
+
+    private static final String SYS_KEY = "pris.test.syskey";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path base;
+
+    @Before
+    public void setUp() throws IOException {
+        base = folder.getRoot().toPath();
+        Files.write(base.resolve("global.properties"), String.join("\n",
+                "shared = from-global",
+                "onlyglobal = global-only",
+                SYS_KEY + " = from-file")
+                .getBytes(StandardCharsets.ISO_8859_1));
+
+        final Path instanceDir = Files.createDirectories(base.resolve("requisitions").resolve("myreq"));
+        Files.write(instanceDir.resolve("requisition.properties"), String.join("\n",
+                "source = xls",
+                "shared = from-instance")
+                .getBytes(StandardCharsets.ISO_8859_1));
+
+        System.setProperty(SYS_KEY, "from-system");
+        System.setProperty("pris.config", base.toString());
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(SYS_KEY);
+        System.clearProperty("pris.config");
+    }
+
+    @Test
+    public void missingGlobalPropertiesIsToleratedAsEmptyConfig() throws IOException {
+        final Path empty = folder.newFolder("empty").toPath();
+        final GlobalApacheConfiguration config = new GlobalApacheConfiguration(empty);
+        assertThat(config.containsKey("onlyglobal"), is(false));
+        assertThat(config.getString("absent", "fallback"), is("fallback"));
+        // system properties remain visible even without a global.properties
+        assertThat(config.getString(SYS_KEY), is("from-system"));
+    }
+
+    @Test
+    public void systemPropertyWinsOverGlobalPropertiesFile() {
+        assertThat(new GlobalApacheConfiguration(base).getString(SYS_KEY), is("from-system"));
+    }
+
+    @Test
+    public void instanceValueWinsOverGlobalValue() {
+        final InstanceConfiguration config = new ConfigManager().getInstanceConfigWithGlobals("myreq");
+        assertThat(config.getString("shared"), is("from-instance"));
+    }
+
+    @Test
+    public void globalValueFillsMissingInstanceKey() {
+        final InstanceConfiguration config = new ConfigManager().getInstanceConfigWithGlobals("myreq");
+        assertThat(config.getString("onlyglobal"), is("global-only"));
+    }
+
+    @Test
+    public void instanceNameIsExposedAsRequisitionProperty() {
+        final InstanceConfiguration config = new ConfigManager().getInstanceConfigWithGlobals("myreq");
+        assertThat(config.getString("requisition"), is("myreq"));
+    }
+}

--- a/opennms-pris-main/src/test/java/org/opennms/pris/config/InstanceApacheConfigurationTest.java
+++ b/opennms-pris-main/src/test/java/org/opennms/pris/config/InstanceApacheConfigurationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 The OpenNMS Group, Inc.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+package org.opennms.pris.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.pris.api.InstanceConfiguration;
+
+/**
+ * Characterization tests pinning down the observable behavior of the
+ * Commons Configuration backed instance configuration. The 2.x migration
+ * (PRIS-181) must keep every one of these green.
+ */
+public class InstanceApacheConfigurationTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path instanceDir;
+
+    @Before
+    public void setUp() throws IOException {
+        instanceDir = folder.newFolder("myreq").toPath();
+        Files.write(instanceDir.resolve("requisition.properties"), String.join("\n",
+                "source = xls",
+                "port = 8000",
+                "flag = true",
+                "tags = alpha, beta",
+                "label = a\\, b",
+                "file = steps.groovy",
+                "scripts = one.groovy, two.groovy",
+                "mapper.script.file = mapper.groovy")
+                .getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    private InstanceConfiguration config() {
+        return new InstanceApacheConfiguration(instanceDir, "myreq");
+    }
+
+    @Test
+    public void loadsPropertiesFromInstanceDirectory() {
+        assertThat(config().getString("source"), is("xls"));
+        assertThat(config().containsKey("source"), is(true));
+        assertThat(config().isEmpty(), is(false));
+        assertThat(config().getInstanceIdentifier(), is("myreq"));
+    }
+
+    @Test
+    public void missingConfigFileFailsNamingThePath() throws IOException {
+        final Path empty = folder.newFolder("empty").toPath();
+        try {
+            new InstanceApacheConfiguration(empty, "empty");
+            throw new AssertionError("expected a RuntimeException for the missing config file");
+        } catch (final RuntimeException ex) {
+            assertThat(ex.getMessage(), containsString("Config file not found"));
+            assertThat(ex.getMessage(), containsString("requisition.properties"));
+        }
+    }
+
+    @Test
+    public void typedAccessorsReturnConfiguredValues() {
+        assertThat(config().getInt("port"), is(8000));
+        assertThat(config().getBoolean("flag"), is(true));
+    }
+
+    @Test
+    public void defaultsApplyForMissingKeys() {
+        assertThat(config().getString("absent", "fallback"), is("fallback"));
+        assertThat(config().getInt("absent", 42), is(42));
+        assertThat(config().getBoolean("absent", true), is(true));
+        assertThat(config().getPath("absent", instanceDir), is(instanceDir));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void missingKeyWithoutDefaultThrowsOnGetString() {
+        config().getString("absent");
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void missingKeyWithoutDefaultThrowsOnGetInt() {
+        config().getInt("absent");
+    }
+
+    @Test
+    public void commaSeparatedValueSplitsIntoArray() {
+        assertThat(config().getStringArray("tags"), arrayContaining("alpha", "beta"));
+    }
+
+    @Test
+    public void commaSeparatedValueJoinsBackOnGetString() {
+        assertThat(config().getString("tags"), is("alpha,beta"));
+    }
+
+    @Test
+    public void escapedCommaStaysASingleValue() {
+        assertThat(config().getStringArray("label"), arrayContaining("a, b"));
+    }
+
+    @Test
+    public void pathResolvesAgainstInstanceDirectory() {
+        assertThat(config().getPath("file"), is(instanceDir.resolve("steps.groovy")));
+    }
+
+    @Test
+    public void pathsResolveAgainstInstanceDirectoryInOrder() {
+        final List<Path> paths = config().getPaths("scripts");
+        assertThat(paths, contains(instanceDir.resolve("one.groovy"),
+                                   instanceDir.resolve("two.groovy")));
+    }
+
+    @Test
+    public void subsetStripsThePrefixAndKeepsIdentity() {
+        final InstanceConfiguration subset = config().subset("mapper");
+        assertThat(subset.getString("script.file"), is("mapper.groovy"));
+        assertThat(subset.containsKey("script.file"), is(true));
+        assertThat(subset.getInstanceIdentifier(), is("myreq"));
+        assertThat(subset.getBasePath(), is(instanceDir));
+        assertThat(subset.getPath("script.file"), is(instanceDir.resolve("mapper.groovy")));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,9 @@
         <apachePoiVersion>5.5.1</apachePoiVersion>
         <beanshellVersion>2.0b5</beanshellVersion>
         <chQosLogbackVersion>1.6.1</chQosLogbackVersion>
-        <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
+        <commonsConfiguration2Version>2.15.1</commonsConfiguration2Version>
+        <!-- commons-configuration2 requires the commons-io version it was
+             built against; keep them in lockstep when bumping either -->
         <commonsIoVersion>2.22.0</commonsIoVersion>
         <commonsLang3Version>3.20.0</commonsLang3Version>
         <downloadMavenPluginVersion>1.13.0</downloadMavenPluginVersion>
@@ -105,9 +107,9 @@
 
             <!-- Configuration -->
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>${commonsConfigurationVersion}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commonsConfiguration2Version}</version>
             </dependency>
 
             <!-- Web-Server -->


### PR DESCRIPTION
Jira: [PRIS-181](https://opennms.atlassian.net/browse/PRIS-181) — remediates [Dependabot alert #11](https://github.com/OpenNMS/opennms-provisioning-integration-server/security/dependabot/11) (CVE-2025-46392, no fixed 1.x version exists).

## Summary
- Replace EOL `commons-configuration:1.10` with `org.apache.commons:commons-configuration2:2.15.1`; the migration touches only the three Apache-backed classes in `opennms-pris-main`'s config layer — the plugin-facing `Configuration` API and all plugins are unchanged.
- **Characterization tests first**: the first commit pins the 1.x behavior (list splitting/escaping, throw-on-missing, path resolution, globals merge precedence, optional `global.properties`, `subset()`) and was committed green against 1.10; the migration commit keeps all 17 green.
- `LegacyListDelimiterHandler(',')` preserves 1.x comma-list semantics (script plugin `file` lists, OCS `tags`).
- Configs load via `FileHandler` instead of the 2.x builder, avoiding the optional `commons-beanutils` dependency entirely.
- The 1.x `FileChangedReloadingStrategy` is dropped: `ConfigManager` rebuilds configs per request, so it never had an observable effect.
- `commons-io` moves to 2.22.0 in lockstep (commons-configuration2 2.15.1 is compiled against its builder APIs; older commons-io fails with `NoSuchMethodError`).

## Verification
- `mvn -pl opennms-pris-main -am test`: 17/17 characterization tests green before and after the swap.
- Full reactor builds; `grep` shows zero remaining `org.apache.commons.configuration.` (1.x) references.
- Container starts and serves; the two locally observed failures (XLS locale test, requisition 500) reproduce identically on clean `master` and are pre-existing — the XLS one is fixed by #167 (PRIS-172).

Independent of the open PR series #167–#170; only disjoint regions of the root `pom.xml` overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRIS-181]: https://opennms.atlassian.net/browse/PRIS-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ